### PR TITLE
feat(example): load remote bpmn diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bpmn-visualization examples
 
-This repository contains examples showing how to use [bpmn-visualization-js](https://github.com/process-analytics/bpmn-visualization-js).
+This repository contains examples showing how to use [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
 ## Demo
 
@@ -21,6 +21,10 @@ If you need BPMN examples, you can use resources
 
 All examples are available live, see [index.html](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html)
 
+### Usage
+
+- [load remote BPMN diagrams](examples/load-remote-bpmn-diagrams/README.md)
+
 ### Extensibility
 
 **DISCLAIMER: extension points are currently very experimental and are subject to changes**
@@ -38,4 +42,4 @@ All examples are available live, see [index.html](https://cdn.statically.io/gh/p
 
 [![statically.io logo](https://statically.io/icons/icon-96x96.png "statically.io")](https://statically.io)
 
-**[statically.io](https://statically.io)** (demo environment)
+**[statically.io](https://statically.io)** (demo environment and live examples)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All examples are available live, see [index.html](https://cdn.statically.io/gh/p
 
 **DISCLAIMER: extension points are currently very experimental and are subject to changes**
 
+- [custom user task icon](./examples/custom-user-task-icon/README.md) use your own icon
 - [custom colors](examples/custom-colors/README.md):
   - change default fill and stroke colors
   - change default font color
@@ -32,7 +33,6 @@ All examples are available live, see [index.html](https://cdn.statically.io/gh/p
 - [custom fonts](examples/custom-fonts/README.md):
   - change default font
   - use specific fonts depending on the BPMN element types
-- [custom user task icon](./examples/custom-user-task-icon/README.md) use your own icon
 
 # Powered by
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -27,13 +27,13 @@ available in the <a href="https://github.com/process-analytics/bpmn-visualizatio
 <h2>Extensibility</h2>
 
 <ul>
+    <li><a href="./custom-user-task-icon/index.html">custom user task icon</a>: use your own icon</li>
     <li><a href="./custom-colors/index.html">custom colors</a>: change default fill and stroke colors, font color, use
         specific colors depending on the BPMN element
     </li>
     <li><a href="./custom-fonts/index.html">custom fonts</a>: change default font, font color, use specific font
         depending on the BPMN element
     </li>
-    <li><a href="./custom-user-task-icon/index.html">custom user task icon</a>: use your own icon</li>
 </ul>
 
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,13 @@ Directly access to <code>bpmn-visualization</code> live examples. Technical deta
 available in the <a href="https://github.com/process-analytics/bpmn-visualization-examples">bpmn-visualization-examples repository</a>.
 
 
+<h2>Usage</h2>
+
+<ul>
+    <li><a href="./load-remote-bpmn-diagrams/index.html">load remote BPMN diagrams</a>: load BPMN diagrams hosted remotely</li>
+</ul>
+
+
 <h2>Extensibility</h2>
 
 <ul>

--- a/examples/load-remote-bpmn-diagrams/README.md
+++ b/examples/load-remote-bpmn-diagrams/README.md
@@ -1,0 +1,6 @@
+# Load Remote BPMN Diagrams
+
+Javascript example provided for `bpmn-visualization@0.1.5`, [index.html](./index.html) or [live](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/load-remote-bpmn-diagrams/index.html)
+
+Use the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to load random files from the
+[bpmn-miwg-test-suite GitHub repository](https://github.com/bpmn-miwg/bpmn-miwg-test-suite).

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -1,0 +1,128 @@
+<!--
+Copyright 2020 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BPMN Visualization - Load remote BPMN diagrams</title>
+    <style>
+        .status-fetching {
+            color: blueviolet;
+            font-style: italic;
+        }
+        .status-ok {
+            color: #2ecc71;
+        }
+        .status-ko {
+            color: red;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+<!-- hack to avoid errors: the demo code requires these ids to add a listener -->
+<div id="bpmn-file"></div>
+<div id="file-selector"></div>
+<!-- DO NOT change this id, the demo code requires it -->
+<div id="graph">
+    <h2>Load remote BPMN diagrams</h2>
+
+    <label for="btn-fetch-miwg">Fetch random file from <a href="https://github.com/bpmn-miwg/bpmn-miwg-test-suite" target="_blank">miwg-test-suite</a></label>
+    <button id="btn-fetch-miwg" title="Fetch from miwg-test-suite">
+        <!-- https://icons.getbootstrap.com/icons/arrow-clockwise/ -->
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-clockwise" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" d="M3.17 6.706a5 5 0 0 1 7.103-3.16.5.5 0 1 0 .454-.892A6 6 0 1 0 13.455 5.5a.5.5 0 0 0-.91.417 5 5 0 1 1-9.375.789z"/>
+            <path fill-rule="evenodd" d="M8.147.146a.5.5 0 0 1 .707 0l2.5 2.5a.5.5 0 0 1 0 .708l-2.5 2.5a.5.5 0 1 1-.707-.708L10.293 3 8.147.854a.5.5 0 0 1 0-.708z"/>
+        </svg>
+    </button>
+    <div id="fetch-status"></div>
+
+</div>
+
+<!-- load global settings -->
+<script src="../../demo/0.1.5/static/js/configureMxGraphGlobals.js"></script>
+<!-- load mxGraph client library -->
+<script src="../../demo/0.1.6/static/js/mxClient.min.js"></script>
+<!-- load bpmn-visualization library -->
+<script src="../../demo/0.1.5/index.es.js"></script>
+
+<script>
+    function log(message, ...optionalParams) {
+        _log('[DEMO]', message, ...optionalParams);
+    }
+    function _log(header, message, ...optionalParams) {
+        console.info(header + ' ' + message, ...optionalParams);
+    }
+    function loadBpmn(bpmn){
+        bpmnVisu.load(bpmn);
+    }
+
+    function statusFetching(url) {
+        const statusElt = document.getElementById('fetch-status');
+        statusElt.innerText = 'Fetching ' + url;
+        statusElt.className = 'status-fetching';
+    }
+
+    function statusFetched(url, duration) {
+        const statusElt = document.getElementById('fetch-status');
+        statusElt.innerText = `Fetch OK (${duration} ms): ${url}`;
+        statusElt.className = 'status-ok';
+    }
+
+    function statusFetchKO(url, error) {
+        const statusElt = document.getElementById('fetch-status');
+        statusElt.innerText = `Unable to fetch ${url}. ${error}`;
+        statusElt.className = 'status-ko';
+    }
+
+    function fetchBpmnContent(url) {
+        log('Fetching BPMN content from url <%s>', url);
+        const startTime = performance.now();
+        statusFetching(url);
+        return fetch(url)
+            .then(response => {
+                if (!response.ok) {
+                    throw Error(String(response.status));
+                }
+                return response.text();
+            })
+            .then(responseBody => {
+                log('BPMN content fetched');
+                const duration = performance.now() - startTime;
+                statusFetched(url, duration);
+                return responseBody;
+            })
+            .catch(error => {
+                statusFetchKO(url, error);
+                throw new Error(`Unable to fetch ${url}. ${error}`);
+            });
+    }
+
+    function loadBpmnFromUrl(url) {
+        fetchBpmnContent(url).then(bpmn => {
+            loadBpmn(bpmn);
+            log('Bpmn loaded from url <%s>', url);
+        });
+    }
+
+    const miwgFileNames = ['A.1.0.bpmn', 'A.2.0.bpmn', 'A.2.1.bpmn', 'B.1.0.bpmn', 'B.2.0.bpmn', 'C.1.0.bpmn', 'C.1.1.bpmn', 'C.2.0.bpmn', 'do-not-exist.bpmn'];
+    document.getElementById('btn-fetch-miwg').onclick = function() {
+        const fileName = miwgFileNames[Math.floor(Math.random() * miwgFileNames.length)];
+        log('Ready to fetch MIWG file %s', fileName);
+        const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
+        loadBpmnFromUrl(url);
+    };
+</script>
+</body>
+</html>


### PR DESCRIPTION
**WIP depends on #15 (global index.html page)**

Example for the 0.1.5 version

Randomly fetch a set of BPMN diagrams from miwg-test-suite to demonstrate
integration with bpmn-visualization by clicking on a button.
The fetching status (pending, success with fetch time, error) is displayed as
well.

