### PR TITLE
[FEAT] add dropdown to select a specific remote diagram

### DIFF
--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -73,6 +73,21 @@ limitations under the License.
                 <span>Fetch random file </span><span class="icon icon-refresh mb-1"></span>
             </button>
             from <a href="https://github.com/bpmn-miwg/bpmn-miwg-test-suite" target="_blank" rel="noopener noreferrer">miwg-test-suite</a>
+            or select one
+            <div class="dropdown mr-2">
+                <a href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
+                    file <span class="icon icon-caret icon-in-the-middle"></span>
+                </a>
+                <!-- TODO fill the list dynamically -->
+                <ul class="menu">
+                    <li><a href="#" class="mr-2 btn btn-link">A.1.0</a></li>
+                    <li><a href="#" class="mr-2 btn btn-link">A.2.0</a></li>
+                    <li><a href="#" class="mr-2 btn btn-link">A.2.1</a></li>
+                    <li><a href="#" class="mr-2 btn btn-link">C.1.0</a></li>
+                    <li><a href="#" class="mr-2 btn btn-link">C.1.1</a></li>
+                    <li><a href="#" class="mr-2 btn btn-link">C.2.0</a></li>
+                </ul>
+            </div>
             <div id="fetch-status"></div>
         </section>
 </section>
@@ -147,6 +162,8 @@ limitations under the License.
         });
     }
 
+    // TODO use this file to fill the dropdown use to load a dedicated file
+    // TODO remove the do not exist file and add it to an array only used for random fetch
     const miwgFileNames = ['A.1.0.bpmn', 'A.2.0.bpmn', 'A.2.1.bpmn',
         'B.1.0.bpmn', 'B.2.0.bpmn',
         'C.1.0.bpmn', 'C.1.1.bpmn', 'C.2.0.bpmn', 'C.3.0.bpmn', 'C.4.0.bpmn',

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -47,7 +47,10 @@ limitations under the License.
         #dropdown-fetch-miwg li {
             margin-top: 0;
         }
-
+        #dropdown-fetch-miwg {
+            min-width: 90px;
+            max-height: 195px;
+        }
         .hidden {
             display: none !important;
         }
@@ -85,8 +88,7 @@ limitations under the License.
                 <a id="dropdown-toggle-fetch-miwg" href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
                     file <span class="icon icon-caret icon-in-the-middle"></span>
                 </a>
-                <!-- TODO reduce interline + externalize style -->
-                <ul class="menu" id="dropdown-fetch-miwg" style="min-width: 90px;">
+                <ul class="menu" id="dropdown-fetch-miwg">
                 </ul>
             </div>
             <div id="fetch-status"></div>

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -161,10 +161,15 @@ limitations under the License.
         loadBpmnFromUrl(url);
     }
 
-    const miwgFileNames = ['A.1.0', 'A.2.0', 'A.2.1',
+    const miwgFileNames = [
+        'A.1.0',
+        'A.2.0', 'A.2.1',
+        'A.3.0',
+        'A.4.0', 'A.4.1',
         'B.1.0', 'B.2.0',
         'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
-        'C.5.0', 'C.6.0'];
+        'C.5.0', 'C.6.0',
+    ];
 
     const randomMiwgFileNames = [...miwgFileNames, 'do-not-exist'];
     document.getElementById('btn-fetch-miwg').onclick = function() {

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -44,6 +44,13 @@ limitations under the License.
         #fetch-status {
             margin: 10px 0;
         }
+        #dropdown-fetch-miwg li {
+            margin-top: 0;
+        }
+
+        .hidden {
+            display: none !important;
+        }
     </style>
 </head>
 <body>
@@ -75,7 +82,7 @@ limitations under the License.
             from <a href="https://github.com/bpmn-miwg/bpmn-miwg-test-suite" target="_blank" rel="noopener noreferrer">miwg-test-suite</a>
             or select a specific
             <div class="dropdown dropdown-right mr-2">
-                <a href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
+                <a id="dropdown-toggle-fetch-miwg" href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
                     file <span class="icon icon-caret icon-in-the-middle"></span>
                 </a>
                 <!-- TODO reduce interline + externalize style -->
@@ -180,21 +187,26 @@ limitations under the License.
 
     // Drop down list
     document.querySelector('#dropdown-fetch-miwg').innerHTML = miwgFileNames.map(fileName => {
-         return `<li><a href="#" class="mr-2 btn btn-link">${fileName}</a></li>`
+         return `<li><a href="#" class="btn btn-link">${fileName}</a></li>`
     }).join('\n');
 
     document.querySelectorAll('#dropdown-fetch-miwg li a')
         .forEach(function (anchor)  {
-            anchor.onclick = function () {
+            anchor.onclick = function (e) {
+                e.preventDefault();
                 // get li value
                 const miwgFileName = anchor.parentElement.innerText;
-                console.log(`miwgFileName: ${miwgFileName}`);
-
                 loadMiwgFile(miwgFileName);
-                // TODO click, don't follow link and close the dropdown
+
+                document.getElementById('dropdown-fetch-miwg').classList.add('hidden');
+
                 return false;
             };
         });
+
+    document.getElementById('dropdown-toggle-fetch-miwg').onclick = function (){
+        document.getElementById('dropdown-fetch-miwg').classList.remove('hidden');
+    }
 </script>
 </body>
 </html>

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -73,7 +73,7 @@ limitations under the License.
                 <span>Fetch random file </span><span class="icon icon-refresh mb-1"></span>
             </button>
             from <a href="https://github.com/bpmn-miwg/bpmn-miwg-test-suite" target="_blank" rel="noopener noreferrer">miwg-test-suite</a>
-            or select one
+            or select a specific
             <div class="dropdown mr-2">
                 <a href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
                     file <span class="icon icon-caret icon-in-the-middle"></span>

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -79,7 +79,7 @@ limitations under the License.
                     file <span class="icon icon-caret icon-in-the-middle"></span>
                 </a>
                 <!-- TODO fill the list dynamically -->
-                <ul class="menu">
+                <ul class="menu" id="dropdown-fetch-miwg">
                     <li><a href="#" class="mr-2 btn btn-link">A.1.0</a></li>
                     <li><a href="#" class="mr-2 btn btn-link">A.2.0</a></li>
                     <li><a href="#" class="mr-2 btn btn-link">A.2.1</a></li>
@@ -162,6 +162,12 @@ limitations under the License.
         });
     }
 
+    function loadMiwgFile(fileName) {
+        log('Ready to fetch MIWG file %s', fileName);
+        const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}.bpmn`;
+        loadBpmnFromUrl(url);
+    }
+
     // TODO use this file to fill the dropdown use to load a dedicated file
     const miwgFileNames = ['A.1.0', 'A.2.0', 'A.2.1',
         'B.1.0', 'B.2.0',
@@ -171,10 +177,22 @@ limitations under the License.
     const randomMiwgFileNames = [...miwgFileNames, 'do-not-exist'];
     document.getElementById('btn-fetch-miwg').onclick = function() {
         const fileName = randomMiwgFileNames[Math.floor(Math.random() * randomMiwgFileNames.length)];
-        log('Ready to fetch MIWG file %s', fileName);
-        const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}.bpmn`;
-        loadBpmnFromUrl(url);
+        loadMiwgFile(fileName);
     };
+
+
+    document.querySelectorAll('#dropdown-fetch-miwg li a')
+        .forEach(function (anchor)  {
+            anchor.onclick = function () {
+                // get li value
+                const miwgFileName = anchor.parentElement.innerText;
+                console.log(`miwgFileName: ${miwgFileName}`);
+
+                loadMiwgFile(miwgFileName);
+                // TODO click, don't follow link and close the dropdown
+                return false;
+            };
+        });
 </script>
 </body>
 </html>

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -163,16 +163,16 @@ limitations under the License.
     }
 
     // TODO use this file to fill the dropdown use to load a dedicated file
-    // TODO remove the do not exist file and add it to an array only used for random fetch
-    const miwgFileNames = ['A.1.0.bpmn', 'A.2.0.bpmn', 'A.2.1.bpmn',
-        'B.1.0.bpmn', 'B.2.0.bpmn',
-        'C.1.0.bpmn', 'C.1.1.bpmn', 'C.2.0.bpmn', 'C.3.0.bpmn', 'C.4.0.bpmn',
-        'C.5.0.bpmn', 'C.6.0.bpmn',
-        'do-not-exist.bpmn'];
+    const miwgFileNames = ['A.1.0', 'A.2.0', 'A.2.1',
+        'B.1.0', 'B.2.0',
+        'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
+        'C.5.0', 'C.6.0'];
+
+    const randomMiwgFileNames = [...miwgFileNames, 'do-not-exist'];
     document.getElementById('btn-fetch-miwg').onclick = function() {
-        const fileName = miwgFileNames[Math.floor(Math.random() * miwgFileNames.length)];
+        const fileName = randomMiwgFileNames[Math.floor(Math.random() * randomMiwgFileNames.length)];
         log('Ready to fetch MIWG file %s', fileName);
-        const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
+        const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}.bpmn`;
         loadBpmnFromUrl(url);
     };
 </script>

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -78,14 +78,7 @@ limitations under the License.
                 <a href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
                     file <span class="icon icon-caret icon-in-the-middle"></span>
                 </a>
-                <!-- TODO fill the list dynamically -->
                 <ul class="menu" id="dropdown-fetch-miwg">
-                    <li><a href="#" class="mr-2 btn btn-link">A.1.0</a></li>
-                    <li><a href="#" class="mr-2 btn btn-link">A.2.0</a></li>
-                    <li><a href="#" class="mr-2 btn btn-link">A.2.1</a></li>
-                    <li><a href="#" class="mr-2 btn btn-link">C.1.0</a></li>
-                    <li><a href="#" class="mr-2 btn btn-link">C.1.1</a></li>
-                    <li><a href="#" class="mr-2 btn btn-link">C.2.0</a></li>
                 </ul>
             </div>
             <div id="fetch-status"></div>
@@ -168,7 +161,6 @@ limitations under the License.
         loadBpmnFromUrl(url);
     }
 
-    // TODO use this file to fill the dropdown use to load a dedicated file
     const miwgFileNames = ['A.1.0', 'A.2.0', 'A.2.1',
         'B.1.0', 'B.2.0',
         'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
@@ -180,6 +172,10 @@ limitations under the License.
         loadMiwgFile(fileName);
     };
 
+    // Drop down list
+    document.querySelector('#dropdown-fetch-miwg').innerHTML = miwgFileNames.map(fileName => {
+         return `<li><a href="#" class="mr-2 btn btn-link">${fileName}</a></li>`
+    }).join('\n');
 
     document.querySelectorAll('#dropdown-fetch-miwg li a')
         .forEach(function (anchor)  {

--- a/examples/load-remote-bpmn-diagrams/index.html
+++ b/examples/load-remote-bpmn-diagrams/index.html
@@ -74,11 +74,12 @@ limitations under the License.
             </button>
             from <a href="https://github.com/bpmn-miwg/bpmn-miwg-test-suite" target="_blank" rel="noopener noreferrer">miwg-test-suite</a>
             or select a specific
-            <div class="dropdown mr-2">
+            <div class="dropdown dropdown-right mr-2">
                 <a href="#" class="btn btn-primary dropdown-toggle" tabindex="0">
                     file <span class="icon icon-caret icon-in-the-middle"></span>
                 </a>
-                <ul class="menu" id="dropdown-fetch-miwg">
+                <!-- TODO reduce interline + externalize style -->
+                <ul class="menu" id="dropdown-fetch-miwg" style="min-width: 90px;">
                 </ul>
             </div>
             <div id="fetch-status"></div>


### PR DESCRIPTION
Also add missing miwg files: 'A.3.0', 'A.4.0', 'A.4.1'

Final design achieved thanks to the @aibcmars help.

Available live while this PR is opened: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/load_remote_diagrams_add_dropdown_list/examples/load-remote-bpmn-diagrams/index.html#

