### PR TITLE
[FEAT] navigation example: allow diagram zoom and pan reset

### DIFF
--- a/examples/diagram-navigation/README.md
+++ b/examples/diagram-navigation/README.md
@@ -1,6 +1,6 @@
 # BPMN Diagram navigation
 
-Javascript example to demonstrate how to navigate the BPMN diagram with the mouse..
+Javascript example to demonstrate how to navigate the BPMN diagram with the mouse.
 - [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 

--- a/examples/diagram-navigation/index.html
+++ b/examples/diagram-navigation/index.html
@@ -67,6 +67,9 @@ limitations under the License.
                         <li>zoom in/out by holding the <kbd>CTRL</kbd> key and rolling the mouse wheel.</li>
                         <li>drag/pan the diagram by holding the mouse left button and moving the mouse to move the diagram within the viewport.</li>
                     </ul>
+                    <button id="btn-reset" title="Reset Zoom and Panning" class="btn btn-primary has-icon-right">
+                        <span>Reset </span><span class="icon icon-refresh mb-1"></span>
+                    </button>
                     <div id="bpmn-viewport-navigation" class="bpmn-viewport"></div>
                 </div>
             </section>
@@ -80,6 +83,11 @@ limitations under the License.
 
         const bpmnVisualizationNavigation = new bpmnvisu.BpmnVisualization(document.getElementById('bpmn-viewport-navigation'), { mouseNavigationSupport: true });
         bpmnVisualizationNavigation.load(bpmnDiagram());
+
+        document.getElementById('btn-reset').onclick = function() {
+            // TODO use the lib method when available, see https://github.com/process-analytics/bpmn-visualization-js/issues/738
+            bpmnVisualizationNavigation.graph.zoomActual();
+        };
 
         function bpmnDiagram() {
             return `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Reset the zoom and diagram position to initial values (i.e. when the diagram is loaded)
Use mxGraph native functions to demonstrate what https://github.com/process-analytics/bpmn-visualization-js/issues/738 will bring to `bpmn-visualization`