### PR TITLE
[FEAT] kie-editors-standalone example access without http server

### DIFF
--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -2,7 +2,7 @@
 
 Javascript example
 - [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/misc/compare-with-kie-editors-standalone/index.html)
-- to run locally, run a web server to open the [index.html](index.html) the page. See the [explanations in the repository README](../../../README.md#running-examples-locally)
+- to run locally, open the [index.html](index.html) directly in a Web Browser
 
 
 ## Overview

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -131,7 +131,8 @@ limitations under the License.
   const kieBpmnEditorContainerId = 'container-kie-editors-standalone';
   const kieBpmnEditor = BpmnEditor.open({
     container: document.getElementById(kieBpmnEditorContainerId),
-    readOnly: false // in 0.7.2-alpha3 and 0.8.1, this is not working as explained in https://blog.kie.org/2020/10/bpmn-and-dmn-standalone-editors.html
+    readOnly: false, // in 0.7.2-alpha3 and 0.8.1, this is not working as explained in https://blog.kie.org/2020/10/bpmn-and-dmn-standalone-editors.html
+    origin: '*', // let use the editor directly from local file i.e. without served by http server
   });
   kieBpmnEditor.subscribeToContentChanges((isDirty) => { logKieBpmn(`Content change detected, isDirty?${isDirty}`)})
 


### PR DESCRIPTION
Still work when accessing the page served by an http server.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/misc_kie-editors-standalone-compare_allow_to_run_without_http_server/examples/index.html 
