### PR TITLE
Clean Vanilla TypeScript project configuration

### DIFF
--- a/examples/projects/typescript-vanilla-with-rollup/tsconfig.json
+++ b/examples/projects/typescript-vanilla-with-rollup/tsconfig.json
@@ -13,11 +13,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
-    "typeRoots": [
-      "node_modules/@types",
-      "node_modules/mxgraph-type-definitions"
-    ]
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Remove extra types declaration in tsconfig.json as we don't have a mxgraph types dependency
in this project.


### Decisions

We have decide to not put mxgraph types in this examples for now.
This may be required for people that want to extend the part our lib relying on mxgraph: the rendering part. We already have js examples for the browser that demonstrate it.
Remember that extensions points are not officially part of the lib and we may replace mxgraph by another lib in a near future (). So, we will then provide examples on this area later.
