### PR TITLE
[REFACTOR] load bpmn-visualization from jsdelivr instead of unpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Custom BPMN Theme features will be progressively added to `bpmn-visualization`. 
 
 ### Custom animation examples
 
+- [Growing Sequence Flow](examples/custom-animation/growing-sequence-flow/README.md) - add custom growing animation on a Sequence Flow
 - [Running Dashed Message Flow](examples/custom-animation/running-dashed-message-flow/README.md) - add custom running dashed animation on a Message Flow
 
 ### Custom interaction examples

--- a/examples/custom-animation/growing-sequence-flow/README.md
+++ b/examples/custom-animation/growing-sequence-flow/README.md
@@ -1,7 +1,7 @@
 # Growing Sequence Flow
 
 Javascript example to demonstrate how to add custom growing animation on a Sequence Flow of the BPMN Diagram.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-animation/growing-sequence-flow/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-animation/growing-sequence-flow/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-animation/growing-sequence-flow/index.html
+++ b/examples/custom-animation/growing-sequence-flow/index.html
@@ -89,7 +89,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="./index.js"></script>
     </body>

--- a/examples/custom-animation/running-dashed-message-flow/README.md
+++ b/examples/custom-animation/running-dashed-message-flow/README.md
@@ -1,7 +1,7 @@
 # Running Dashed Message Flow
 
 Javascript example to demonstrate how to add custom running dashed animation on a Message Flow of the BPMN Diagram.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-animation/running-dashed-message-flow/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-animation/running-dashed-message-flow/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-animation/running-dashed-message-flow/index.html
+++ b/examples/custom-animation/running-dashed-message-flow/index.html
@@ -89,7 +89,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="./index.js"></script>
     </body>

--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -4,7 +4,7 @@
 In particular, the way of changing the defaults will be done via configuration in the future.
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-colors/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-colors/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -64,7 +64,7 @@ limitations under the License.
 
     <script src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
     <!-- load the example -->
     <script src="../../static/js/bpmn-diagrams.js"></script>
     <script src="./custom-colors.js"></script>

--- a/examples/custom-bpmn-theme/custom-fonts/README.md
+++ b/examples/custom-bpmn-theme/custom-fonts/README.md
@@ -4,7 +4,7 @@
 In particular, the way of changing the defaults will be done via configuration in the future.
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-fonts/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-fonts/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 

--- a/examples/custom-bpmn-theme/custom-fonts/index.html
+++ b/examples/custom-bpmn-theme/custom-fonts/index.html
@@ -61,7 +61,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 <!-- load the example -->
 <script src="../../static/js/bpmn-diagrams.js"></script>
 <script src="./custom-fonts.js"></script>

--- a/examples/custom-bpmn-theme/custom-user-task-icon/README.md
+++ b/examples/custom-bpmn-theme/custom-user-task-icon/README.md
@@ -5,7 +5,7 @@ The current way of doing is a hack as there is no official way of doing it. In t
 subclassing `IconPainter`.
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-user-task-icon/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/custom-user-task-icon/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ BPMN Visualization Usage

--- a/examples/custom-bpmn-theme/custom-user-task-icon/index.html
+++ b/examples/custom-bpmn-theme/custom-user-task-icon/index.html
@@ -56,7 +56,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 <!-- load the example -->
 <script src="../../static/js/bpmn-diagrams.js"></script>
 <script src="./custom-user-task-icon.js"></script>

--- a/examples/custom-bpmn-theme/hacktoberfest-diagram/README.md
+++ b/examples/custom-bpmn-theme/hacktoberfest-diagram/README.md
@@ -4,7 +4,7 @@
 In particular, the way of changing the defaults will be done via configuration in the future.
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/hacktoberfest-diagram/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-bpmn-theme/hacktoberfest-diagram/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 

--- a/examples/custom-bpmn-theme/hacktoberfest-diagram/index.html
+++ b/examples/custom-bpmn-theme/hacktoberfest-diagram/index.html
@@ -69,7 +69,7 @@ limitations under the License.
 
     <script src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
     <!-- load the example -->
     <script src="../../static/js/bpmn-diagrams.js"></script>
     <script src="./hacktoberfest-diagram.js"></script>

--- a/examples/custom-interaction/apply-css-classes/README.md
+++ b/examples/custom-interaction/apply-css-classes/README.md
@@ -1,7 +1,7 @@
 # Apply css to BPMN elements
 
 Javascript example to demonstrate how to apply CSS classes to elements of the BPMN Diagram.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/apply-css-classes/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/apply-css-classes/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-interaction/apply-css-classes/index.html
+++ b/examples/custom-interaction/apply-css-classes/index.html
@@ -151,7 +151,7 @@ limitations under the License.
     </section>
 
     <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
     <script src="../../static/js/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
     <script>
         const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true} });

--- a/examples/custom-interaction/javascript-tooltip-and-popover/README.md
+++ b/examples/custom-interaction/javascript-tooltip-and-popover/README.md
@@ -1,7 +1,7 @@
 # Attach tooltip and popover to BPMN elements
 
 Javascript example to demonstrate how to identify HtmlElement related to BPMN diagram elements and retrieve BPMN information.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/javascript-tooltip-and-popover/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/javascript-tooltip-and-popover/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-interaction/javascript-tooltip-and-popover/index.html
+++ b/examples/custom-interaction/javascript-tooltip-and-popover/index.html
@@ -87,7 +87,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="index.js"></script>
     </body>

--- a/examples/custom-interaction/popover-static/README.md
+++ b/examples/custom-interaction/popover-static/README.md
@@ -1,7 +1,7 @@
 # Add a popover with information to the task found by it's id
 
 Javascript example to demonstrate how to open a new BPMN diagram in a tab.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/popover/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/popover/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-interaction/popover-static/index.html
+++ b/examples/custom-interaction/popover-static/index.html
@@ -116,7 +116,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="../../static/js/dom-helper.js"></script>
         <script src="./index.js"></script>

--- a/examples/custom-interaction/select-elements-by-bpmn-kind/README.md
+++ b/examples/custom-interaction/select-elements-by-bpmn-kind/README.md
@@ -2,7 +2,7 @@
 
 
 Javascript example to demonstrate how to select elements by BPMN kind and register custom behaviour on found elements
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/select-elements-by-bpmn-kind/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-interaction/select-elements-by-bpmn-kind/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-interaction/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-interaction/select-elements-by-bpmn-kind/index.html
@@ -130,7 +130,7 @@ limitations under the License.
     </section>
 
     <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
     <script src="../../static/js/bpmn-diagram-miwg-test-suite-a_4_1.js"></script>
     <script src="../../static/js/bpmn-diagram-miwg-test-suite-c_1_0.js"></script>
     <script src="../../static/js/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>

--- a/examples/custom-navigation/call-activity-with-modal-on-mouse-over/README.md
+++ b/examples/custom-navigation/call-activity-with-modal-on-mouse-over/README.md
@@ -1,7 +1,7 @@
 # Open a modal on event on a call activity
 
 Javascript example to demonstrate how to open a new BPMN diagram in a modal.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html
+++ b/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html
@@ -80,7 +80,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="./index.js"></script>
         <script src="./modal.js"></script>

--- a/examples/custom-navigation/call-activity-with-reload-on-dblclick/README.md
+++ b/examples/custom-navigation/call-activity-with-reload-on-dblclick/README.md
@@ -1,7 +1,7 @@
 # Load BPMN Diagram in the same container on double click on a call activity
 
 Javascript example to demonstrate how to use the same container on a double click on an element of the BPMN Diagram.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-reload-on-dblclick/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-reload-on-dblclick/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-navigation/call-activity-with-reload-on-dblclick/index.html
+++ b/examples/custom-navigation/call-activity-with-reload-on-dblclick/index.html
@@ -73,7 +73,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="./index.js"></script>
         <script src="./breadcrumbs.js"></script>

--- a/examples/custom-navigation/call-activity-with-tabs-on-click/README.md
+++ b/examples/custom-navigation/call-activity-with-tabs-on-click/README.md
@@ -1,7 +1,7 @@
 # Switch tab (of the page) on click on a call activity
 
 Javascript example to demonstrate how to open a new BPMN diagram in a tab.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-tabs-on-click/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/custom-navigation/call-activity-with-tabs-on-click/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/custom-navigation/call-activity-with-tabs-on-click/index.html
+++ b/examples/custom-navigation/call-activity-with-tabs-on-click/index.html
@@ -75,7 +75,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="./index.js"></script>
     </body>

--- a/examples/diagram-navigation/diagram-fit-after-load/README.md
+++ b/examples/diagram-navigation/diagram-fit-after-load/README.md
@@ -1,7 +1,7 @@
 # BPMN Diagram fit after load
 
 Javascript example to demonstrate how can fit the BPMN diagram after load.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-fit-after-load/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-fit-after-load/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/diagram-navigation/diagram-fit-after-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-after-load/index.html
@@ -131,7 +131,7 @@ limitations under the License.
 
     <script src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
     <script src="../../static/js/bpmn-diagrams.js"></script>
     <script>

--- a/examples/diagram-navigation/diagram-fit-on-load/README.md
+++ b/examples/diagram-navigation/diagram-fit-on-load/README.md
@@ -1,7 +1,7 @@
 # Fit BPMN Diagram on load
 
 Javascript example to demonstrate how can fit the BPMN diagram on load.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-fit-on-load/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-fit-on-load/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/diagram-navigation/diagram-fit-on-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-on-load/index.html
@@ -105,7 +105,7 @@ limitations under the License.
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
         <script src="../../static/js/bpmn-diagrams.js"></script>
         <script src="diagram-fit-on-load.js"></script>
     </body>

--- a/examples/diagram-navigation/diagram-navigation/README.md
+++ b/examples/diagram-navigation/diagram-navigation/README.md
@@ -1,7 +1,7 @@
 # BPMN Diagram navigation
 
 Javascript example to demonstrate how to navigate the BPMN diagram with the mouse.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-navigation/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/diagram-navigation/diagram-navigation/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -76,7 +76,7 @@ limitations under the License.
     </section>
 
     <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
     <script src="../../static/js/bpmn-diagrams.js"></script>
     <script>
         const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-default' });

--- a/examples/display-bpmn-diagram/01-getting-started/README.md
+++ b/examples/display-bpmn-diagram/01-getting-started/README.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 Javascript example to demonstrate how to integrate `bpmn-visualization` in an html page.
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/01-getting-started/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/01-getting-started/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/display-bpmn-diagram/01-getting-started/README.md
+++ b/examples/display-bpmn-diagram/01-getting-started/README.md
@@ -7,15 +7,15 @@ Javascript example to demonstrate how to integrate `bpmn-visualization` in an ht
 ## ♻️ Usage
 
 ### Load the library
-Load the browser bundle from [unpkg](https://unpkg.com/browse/bpmn-visualization), [jsdelivr](https://www.jsdelivr.com/package/npm/bpmn-visualization),
+Load the browser bundle from [jsdelivr](https://www.jsdelivr.com/package/npm/bpmn-visualization), [unpkg](https://unpkg.com/browse/bpmn-visualization)
 or any other location:
 ```html
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 ```
 
 💡 During the development step, you can use the non-minified version:
 ```html
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.js"></script>
 ```
 
 ### Use the library

--- a/examples/display-bpmn-diagram/01-getting-started/index.html
+++ b/examples/display-bpmn-diagram/01-getting-started/index.html
@@ -51,7 +51,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 <!-- if you prefer jsdlivr, comment unpkg and uncomment the following line -->
 <!--<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>-->
 <script src="../../static/js/bpmn-diagrams.js"></script>

--- a/examples/display-bpmn-diagram/load-local-bpmn-diagrams/README.md
+++ b/examples/display-bpmn-diagram/load-local-bpmn-diagrams/README.md
@@ -1,7 +1,7 @@
 # Load Local BPMN Diagrams
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ Usage

--- a/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
@@ -89,7 +89,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 <script>
     document.getElementById('btn-open-file').addEventListener('change', handleFileSelect, false);
 

--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/README.md
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/README.md
@@ -1,7 +1,7 @@
 # Load Remote BPMN Diagrams
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 ## ♻️ BPMN Visualization Usage

--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
@@ -102,7 +102,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
 <script>
     const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container' });

--- a/examples/misc/compare-with-bpmn-js/README.md
+++ b/examples/misc/compare-with-bpmn-js/README.md
@@ -1,7 +1,7 @@
 # Compare bpmn-visualization and bpmn-js when loading Local BPMN Diagrams
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/misc/compare-with-bpmn-js/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/misc/compare-with-bpmn-js/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -121,7 +121,7 @@ limitations under the License.
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.0.0/dist/bpmn-navigated-viewer.development.js" integrity="sha256-jekX8LQFqELwZ4+20YvA3OAGIQk1YmWfksmAPBhi48c=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
 <script>
   const bpmnVisualizationContainerId = 'container-bpmn-visualization';

--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -1,7 +1,7 @@
 # Compare bpmn-visualization and kie-editors-standalone when loading Local BPMN Diagrams
 
 Javascript example
-- [__:fast_forward: live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/misc/compare-with-kie-editors-standalone/index.html)
+- [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/misc/compare-with-kie-editors-standalone/index.html)
 - to run locally, open the [index.html](index.html) directly in a Web Browser
 
 

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -123,7 +123,7 @@ limitations under the License.
 <!-- load bpmn kie-editors-standalone -->
 <script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.8.1/dist/bpmn/index.js" integrity="sha256-zQouSvQPpMHn0SS9CkEFj0vkPh+Q0rGBc0SInk+pCVs=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
-<script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
 <script>
   const bpmnVisualizationContainerId = 'container-bpmn-visualization';


### PR DESCRIPTION
This is a larger CDN and is generally faster.

In addition, improve the documentation
  - live environment links: use emoji instead github syntax for better rendering
  in all markdown viewers
  - main readme: add missing 'Growing Sequence Flow' example 


**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/get_lib_from_jsdelivr_and_icon_updates/examples/index.html