### PR TITLE
[FEAT] bump bpmn-js and kie-editors-standalone libs

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -119,8 +119,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.0.0/dist/bpmn-navigated-viewer.development.js" integrity="sha256-jekX8LQFqELwZ4+20YvA3OAGIQk1YmWfksmAPBhi48c=" crossorigin="anonymous"></script>
-<!-- load bpmn-visualization -->
+<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.2.1/dist/bpmn-navigated-viewer.development.js" integrity="sha256-FhuUxPNXTbWj4wMZePAxPdkgvU6BQMotr8ymPD/M4vA=" crossorigin="anonymous"></script><!-- load bpmn-visualization -->
 <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
 <script>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -119,7 +119,8 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.2.1/dist/bpmn-navigated-viewer.development.js" integrity="sha256-FhuUxPNXTbWj4wMZePAxPdkgvU6BQMotr8ymPD/M4vA=" crossorigin="anonymous"></script><!-- load bpmn-visualization -->
+<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.2.1/dist/bpmn-navigated-viewer.development.js" integrity="sha256-FhuUxPNXTbWj4wMZePAxPdkgvU6BQMotr8ymPD/M4vA=" crossorigin="anonymous"></script>
+<!-- load bpmn-visualization -->
 <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
 <script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -121,7 +121,7 @@ limitations under the License.
 <script src="../../static/js/link-to-sources.js"></script>
 <script src="../../static/js/dom-helper.js"></script>
 <!-- load bpmn kie-editors-standalone -->
-<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.8.1/dist/bpmn/index.js" integrity="sha256-zQouSvQPpMHn0SS9CkEFj0vkPh+Q0rGBc0SInk+pCVs=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.8.3/dist/bpmn/index.js" integrity="sha256-Ax1DKGo7EIqUAs3tDXOSxI6MB1exbbEMTL6VHFHHAwo=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://unpkg.com/bpmn-visualization@0.12.2/dist/bpmn-visualization.min.js"></script>
 
@@ -133,7 +133,7 @@ limitations under the License.
   const kieBpmnEditor = BpmnEditor.open({
     container: document.getElementById(kieBpmnEditorContainerId),
     readOnly: false, // in 0.7.2-alpha3 and 0.8.1, this is not working as explained in https://blog.kie.org/2020/10/bpmn-and-dmn-standalone-editors.html
-    origin: '*', // let use the editor directly from local file i.e. without served by http server
+    // origin: '*', // let use the editor directly from local file i.e. without served by http server
   });
   kieBpmnEditor.subscribeToContentChanges((isDirty) => { logKieBpmn(`Content change detected, isDirty?${isDirty}`)})
 

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -133,7 +133,6 @@ limitations under the License.
   const kieBpmnEditor = BpmnEditor.open({
     container: document.getElementById(kieBpmnEditorContainerId),
     readOnly: false, // in 0.7.2-alpha3 and 0.8.1, this is not working as explained in https://blog.kie.org/2020/10/bpmn-and-dmn-standalone-editors.html
-    // origin: '*', // let use the editor directly from local file i.e. without served by http server
   });
   kieBpmnEditor.subscribeToContentChanges((isDirty) => { logKieBpmn(`Content change detected, isDirty?${isDirty}`)})
 


### PR DESCRIPTION
Bump
  - bpmn-js from 8.0.0 to 8.2.1
  - kie-editors-standalone from 0.8.1 to 0.8.3

closes #132


**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/bump_bpmn_competitors_lib_versions/examples/index.html