### PR TITLE
[DOC] update info about kie-editors-standalone

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -577,7 +577,7 @@ limitations under the License.
                                     <img src="static/img/preview/misc/compare-with-kie-editors-standalone.png" class="img-responsive" alt="compare with kie-editors-standalone">
                                 </div>
                                 <div class="card-body">Compare the libraries on BPMN elements rendering and API usage.<br>
-                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (more than 36 Mb, download almost 7 Mb gzipped data)
+                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (almost 28 MB, more than 5 MB after compression)
                                     and slow to initialize.</div>
                                 <div class="card-footer"></div>
                             </div>

--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -12,10 +12,9 @@ This example let you compare [bpmn-visualization](https://github.com/process-ana
 - API usage
 
 **WARN** \
-The following applies at least to `kie-editors-standalone@0.8.1`
-- The  js bundle is very large (more than 38mb), very slow to load and generates a lot of error in the console.
+The following applies at least to `kie-editors-standalone@0.8.3`
+- The javascript bundle is very large (almost 28 MB, more than 5 MB after compression), very slow to load and generates a lot of error in the console.
 - It is unable to display most of the C.x diagrams from the miwg-test-suite (parsing errors).
-- You must serve this example with a http server (see link on top of this file), otherwise, the diagram won't load in kie-editors-standalone (`window.location.origin` issue).
 
 
 ## Implementation notes


### PR DESCRIPTION
The bundle size has decreased when upgrading from 0.8.1 to 0.8.3.
The example doesn't need a web server.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/doc/update_info_about_kie-editors-standalone/examples/index.html