### PR TITLE
[FEAT] Bump competitor libs used in the comparison examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -615,7 +615,7 @@ limitations under the License.
                                     <img src="static/img/preview/misc/compare-with-kie-editors-standalone.png" class="img-responsive" alt="compare with kie-editors-standalone">
                                 </div>
                                 <div class="card-body">Compare the libraries on BPMN elements rendering and API usage.<br>
-                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (almost 28 MB, more than 5 MB after compression)
+                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (29 MB, more than 5 MB after compression)
                                     and slow to initialize.</div>
                                 <div class="card-footer"></div>
                             </div>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -119,7 +119,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.2.1/dist/bpmn-navigated-viewer.development.js" integrity="sha256-FhuUxPNXTbWj4wMZePAxPdkgvU6BQMotr8ymPD/M4vA=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.3.1/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-AhFInovxE2yAuaEW0AKizkC654o6NmQ5HTkCrt9UbuA=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.14.0/dist/bpmn-visualization.min.js"></script>
 

--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -12,8 +12,8 @@ This example let you compare [bpmn-visualization](https://github.com/process-ana
 - API usage
 
 **WARN** \
-The following applies at least to `kie-editors-standalone@0.8.3`
-- The javascript bundle is very large (almost 28 MB, more than 5 MB after compression), very slow to load and generates a lot of error in the console.
+The following applies at least to `kie-editors-standalone@0.9.0`
+- The javascript bundle is very large (29 MB, more than 5 MB after compression), very slow to load and generates a lot of error in the console.
 - It is unable to display most of the C.x diagrams from the miwg-test-suite (parsing errors).
 
 

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -121,7 +121,7 @@ limitations under the License.
 <script src="../../static/js/link-to-sources.js"></script>
 <script src="../../static/js/dom-helper.js"></script>
 <!-- load bpmn kie-editors-standalone -->
-<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.8.3/dist/bpmn/index.js" integrity="sha256-Ax1DKGo7EIqUAs3tDXOSxI6MB1exbbEMTL6VHFHHAwo=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.9.0/dist/bpmn/index.js" integrity="sha256-H1nZXun5ICKj3MrVTfiT7cM7neoeC8UYUnTB6ustrZk=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.14.0/dist/bpmn-visualization.min.js"></script>
 
@@ -132,7 +132,7 @@ limitations under the License.
   const kieBpmnEditorContainerId = 'container-kie-editors-standalone';
   const kieBpmnEditor = BpmnEditor.open({
     container: document.getElementById(kieBpmnEditorContainerId),
-    readOnly: false, // in 0.7.2-alpha3 and 0.8.1, this is not working as explained in https://blog.kie.org/2020/10/bpmn-and-dmn-standalone-editors.html
+    readOnly: true, // available as of 0.9.0 (https://blog.kie.org/2021/04/design-tools-highlights-on-kogito-and-business-central-april-2021.html)
   });
   kieBpmnEditor.subscribeToContentChanges((isDirty) => { logKieBpmn(`Content change detected, isDirty?${isDirty}`)})
 


### PR DESCRIPTION
kie-editors-standalone: bump from 0.8.3 to 0.9.0
Activate the read-only mode that is now available

bpmn-js: bump from 8.2.1 to 8.3.1

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bump_competitor_libs_version/examples/index.html