### PR TITLE
[FEAT] Align wording of the example home page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -163,7 +163,7 @@ limitations under the License.
                     <h5>Content</h5>
                     <ul>
                         <li><a href="#demos">Demos</a></li>
-                        <li><a href="#display-bpmn-theme">BPMN Diagram rendering</a></li>
+                        <li><a href="#bpmn-rendering">BPMN rendering</a></li>
                         <li><a href="#diagram-navigation">Diagram navigation</a></li>
                         <li><a href="#overlays">Overlays</a></li>
                         <li><a href="#custom-bpmn-theme">Custom BPMN Theme</a></li>
@@ -215,8 +215,8 @@ limitations under the License.
             </section>
 
             <section class="col-12 mt-2 mb-2">
-                <a id="display-bpmn-theme" class="anchor-from-summary"></a>
-                <h2 class="bg-dark">BPMN Diagram Rendering</h2>
+                <a id="bpmn-rendering" class="anchor-from-summary"></a>
+                <h2 class="bg-dark">BPMN Rendering</h2>
                 <div class="columns">
                     <div class="col-4 p-2">
                         <!-- TODO tabindex="-1" to make it temporary non focusable to avoid glitch -->

--- a/examples/index.html
+++ b/examples/index.html
@@ -163,13 +163,13 @@ limitations under the License.
                     <h5>Content</h5>
                     <ul>
                         <li><a href="#demos">Demos</a></li>
-                        <li><a href="#display-bpmn-theme">Display BPMN Diagram examples</a></li>
-                        <li><a href="#diagram-navigation">Diagram navigation examples</a></li>
-                        <li><a href="#overlays">Overlay examples</a></li>
-                        <li><a href="#custom-bpmn-theme">Custom BPMN Theme examples</a></li>
-                        <li><a href="#custom-animation">Custom animation examples</a></li>
-                        <li><a href="#custom-behavior">Custom behavior examples</a></li>
-                        <li><a href="#miscellaneous">Miscellaneous examples</a></li>
+                        <li><a href="#display-bpmn-theme">BPMN Diagram rendering</a></li>
+                        <li><a href="#diagram-navigation">BPMN Diagram navigation</a></li>
+                        <li><a href="#overlays">Overlays</a></li>
+                        <li><a href="#custom-bpmn-theme">Custom BPMN Theme</a></li>
+                        <li><a href="#custom-animation">Custom animation</a></li>
+                        <li><a href="#custom-behavior">Custom behavior</a></li>
+                        <li><a href="#miscellaneous">Miscellaneous</a></li>
                     </ul>
                     <br>
 
@@ -216,7 +216,7 @@ limitations under the License.
 
             <section class="col-12 mt-2 mb-2">
                 <a id="display-bpmn-theme" class="anchor-from-summary"></a>
-                <h2 class="bg-dark">Display BPMN Diagram</h2>
+                <h2 class="bg-dark">BPMN Diagram Rendering</h2>
                 <div class="columns">
                     <div class="col-4 p-2">
                         <!-- TODO tabindex="-1" to make it temporary non focusable to avoid glitch -->
@@ -271,7 +271,7 @@ limitations under the License.
 
             <section class="col-12 mt-2 mb-2">
                 <a id="diagram-navigation" class="anchor-from-summary"></a>
-                <h2 class="bg-dark">Diagram navigation</h2>
+                <h2 class="bg-dark">BPMN Diagram navigation</h2>
                 <div class="columns">
                     <div class="col-4 p-2">
                         <a href="diagram-navigation/diagram-navigation/index.html" target="_blank" class="card-link">

--- a/examples/index.html
+++ b/examples/index.html
@@ -164,7 +164,7 @@ limitations under the License.
                     <ul>
                         <li><a href="#demos">Demos</a></li>
                         <li><a href="#display-bpmn-theme">BPMN Diagram rendering</a></li>
-                        <li><a href="#diagram-navigation">BPMN Diagram navigation</a></li>
+                        <li><a href="#diagram-navigation">Diagram navigation</a></li>
                         <li><a href="#overlays">Overlays</a></li>
                         <li><a href="#custom-bpmn-theme">Custom BPMN Theme</a></li>
                         <li><a href="#custom-animation">Custom animation</a></li>
@@ -271,7 +271,7 @@ limitations under the License.
 
             <section class="col-12 mt-2 mb-2">
                 <a id="diagram-navigation" class="anchor-from-summary"></a>
-                <h2 class="bg-dark">BPMN Diagram navigation</h2>
+                <h2 class="bg-dark">Diagram navigation</h2>
                 <div class="columns">
                     <div class="col-4 p-2">
                         <a href="diagram-navigation/diagram-navigation/index.html" target="_blank" class="card-link">


### PR DESCRIPTION
Replace 'display' by 'rendering'
Remove extra 'example' word from the summary (no need to repeat example here as we are in the example home page)

covers https://github.com/process-analytics/bpmn-visualization-js/issues/1259

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/index_wording_update/examples/index.html
