### PR TITLE
[FEAT] Simplify the 'diagram navigation' example

### DIFF
--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -24,7 +24,7 @@ limitations under the License.
         .bpmn-container {
             /* use absolute values for width and height to ensure that the diagram is not fully displayed when the page is opened. */
             width: 800px;
-            height: 300px;
+            height: 400px;
             margin-top: 2em;
             border-style: solid;
             border-color: #B0B0B0;
@@ -56,21 +56,17 @@ limitations under the License.
     <section class="container col-10 flex-centered mt-2">
             <section class="col-12 mt-2">
                 <div class="col-12 mb-2">
-                    <h2>Default (no navigation)</h2>
-                    The diagram is too large and does not fit within the container.
-                    <div id="bpmn-container-default" class="bpmn-container"></div>
-                </div>
-                <div class="col-12 mt-40 mb-2">
-                    <h2>With Diagram Navigation enabled</h2>
+                    <h2>Diagram Navigation</h2>
+                    The diagram is too large and does not fit within the container.<br>
                     Diagram navigation is enabled here, you can:
                     <ul>
                         <li>zoom in/out by holding the <kbd>CTRL</kbd> key and rolling the mouse wheel.</li>
                         <li>drag/pan the diagram by holding the mouse left button and moving the mouse to move the diagram within the container.</li>
                     </ul>
-                    <button id="btn-reset" title="Reset Zoom and Panning" class="btn btn-primary has-icon-right">
+                    <button id="btn-reset" title="Reset Zoom and Pan" class="btn btn-primary has-icon-right">
                         <span>Reset </span><span class="icon icon-refresh mb-1"></span>
                     </button>
-                    <div id="bpmn-container-navigation" class="bpmn-container"></div>
+                    <div id="bpmn-container" class="bpmn-container"></div>
                 </div>
             </section>
     </section>
@@ -78,15 +74,6 @@ limitations under the License.
     <script src="../../static/js/link-to-sources.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.14.1/dist/bpmn-visualization.min.js"></script>
     <script src="../../static/js/bpmn-diagrams.js"></script>
-    <script>
-        const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-default' });
-        bpmnVisualization.load(getNavigationBpmnDiagram());
-
-        const bpmnVisualizationNavigation = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-navigation', navigation: { enabled: true } });
-        bpmnVisualizationNavigation.load(getNavigationBpmnDiagram());
-
-        document.getElementById('btn-reset').onclick = function() {
-            bpmnVisualizationNavigation.fit({type: bpmnvisu.FitType.None});
-        };
-    </script></body>
+    <script src="./index.js"></script>
+</body>
 </html>

--- a/examples/diagram-navigation/diagram-navigation/index.js
+++ b/examples/diagram-navigation/diagram-navigation/index.js
@@ -1,0 +1,8 @@
+console.info('je suis la')
+
+const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true } });
+bpmnVisualization.load(getNavigationBpmnDiagram());
+
+document.getElementById('btn-reset').onclick = function() {
+  bpmnVisualization.fit({type: bpmnvisu.FitType.None});
+};


### PR DESCRIPTION
Only keep a single container where the user can do 'diagram navigation': this
let us have a larger container
Extract the javascript in a dedicated file

Refs #171 

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/simplify_diagram_navigation_example/examples/index.html
