### PR TITLE
[INFRA] Bump 3rd party libs in the popup/popover custom behavior example

### DIFF
--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.html
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.html
@@ -20,7 +20,7 @@ limitations under the License.
         <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
         <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
         <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-        <link rel="stylesheet" href="https://unpkg.com/tippy.js@6.2.7/themes/light-border.css" integrity="sha256-Fev9TKDfIZRihMeo+VloYBQ6vG1Pehn17SF0wQE1w/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tippy.js@6.3.1/themes/light-border.css" integrity="sha256-Fev9TKDfIZRihMeo+VloYBQ6vG1Pehn17SF0wQE1w/0=" crossorigin="anonymous">
         <style>
             #bpmn-container {
                 /* use absolute values for height to ensure that the vertical diagram is not fully displayed when the page is opened. */
@@ -81,9 +81,9 @@ limitations under the License.
         </section>
 
         <!-- Popover and Tooltip support -->
-        <script src="https://unpkg.com/@popperjs/core@2.5.4/dist/umd/popper.min.js" integrity="sha256-GLgOQLuTrl+PHTJTsD2OXVW1E0GifteM9C/q3QErz58=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha256-WgfGn5Bh6xLjmgMTWKT1Z/MKACrWGCY5rIT9G9ovbmU=" crossorigin="anonymous"></script>
         <!-- Development version -->
-        <script src="https://unpkg.com/tippy.js@6.2.7/dist/tippy-bundle.umd.js" integrity="sha256-3z2wAdHxAq5cS54s7UKGEmkeVxP15cjPx2+pDIHhEE4=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.1/dist/tippy-bundle.umd.js" integrity="sha256-mII5pSbIKUGuLuv63S7irex7OpIvGzxRkcXP+jOAIu4=" crossorigin="anonymous"></script>
 
         <script src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->

--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.js
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.js
@@ -11,13 +11,12 @@ const registeredBpmnElements = new Map();
 const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
 const elementsWithPopover = bpmnElementsRegistry.getElementsByIds([
     'Activity_1j15wcw', // manual task 3
-    'Activity_0y3sd80' //script task 5
+    'Activity_0y3sd80', //script task 5
 ]);
 const elementsWithPopup = bpmnElementsRegistry.getElementsByIds([
     'Activity_0kn4d46', // user task 2
-    'Flow_12yysoe' // sequence flow between 'task 5' and 'end event'
+    'Flow_12yysoe', // sequence flow between 'task 5' and 'end event'
 ]);
-
 
 
 // tippy global configuration
@@ -62,25 +61,16 @@ tippy.setDefaultProps({
     // moveTransition: 'transform 0.2s ease-out',
 });
 
-// popover on shapes
-// addPopover([manualTask3Elt, scriptTask5Elt]);
 addPopover(elementsWithPopover);
-
-// popup on edges
-// addPopup([sequenceFlowBetweenTask5AndEndEventElt], true);
-// // popup on shapes
-// addPopup([userTask2Elt]);
 addPopup(elementsWithPopup);
 
 
 function addPopover(bpmnElements) {
     registerBpmnElements(bpmnElements);
-    const htmlElements = bpmnElements.map(elt => elt.htmlElement)
-
     // Set the cursor to mark the elements as clickable
-    // TODO don't work with diagram navigation, use new API when available (see https://github.com/process-analytics/bpmn-visualization-js/issues/942)
-    htmlElements.forEach(elt => elt.classList.add('c-hand'));
+    bpmnVisualization.bpmnElementsRegistry.addCssClasses(bpmnElements.map(element => element.bpmnSemantic.id), 'c-hand');
 
+    const htmlElements = bpmnElements.map(elt => elt.htmlElement)
     tippy(htmlElements, {
         // sticky option behaviour with this appendTo
         // The following is only needed to manage diagram navigation
@@ -124,43 +114,19 @@ function addPopover(bpmnElements) {
 function addPopup(bpmnElements) {
     registerBpmnElements(bpmnElements);
 
-    // const isEdge = false;
-    // const offset = isEdge? [0, -40] : undefined;
-    //
-    // const htmlElements = bpmnElements.map(elt => elt.htmlElement)
-
     bpmnElements.forEach(bpmnElement => {
         const htmlElement = bpmnElement.htmlElement;
         const isEdge = !bpmnElement.bpmnSemantic.isShape;
         const offset = isEdge? [0, -40] : undefined; // undefined offset for tippyjs default offset
 
         tippy(htmlElement, {
-            // sticky option behaviour with this appendTo
-            // The following is only needed to manage diagram navigation
-            // Current issue while pan, the dimension of the popper changed while dragging which may also wrongly trigger a flip
-            // during the pan and then, an new flip after dimensions are restored
-            // for issue on pan, this may help: https://github.com/atomiks/tippyjs/issues/688
-
-            // Notice that we cannot have the same configuration when we trigger on mouseover/focus or on click
-
-            // When trigger on click
-            // 'reference': work with zoom (do not move the popper), but disappear on pan, mainly vertical pan (translation computation issue)
-            // 'popper': do not move on zoom, move on pan but also change the dimension of the tooltip while pan)
-            // appendTo: bpmnContainerElt,
-
-            // When trigger on click
-            // when using this, no resize issue on pan, but no more flip nor overflow. We can however use sticky: 'reference' with is better
+            // work perfectly on hover with or without 'diagram navigation' enable
             appendTo: bpmnContainerElt.parentElement,
-
 
             // https://atomiks.github.io/tippyjs/v6/all-props/#sticky
             // This has a performance cost since checks are run on every animation frame. Use this only when necessary!
-            // enable it
-            //sticky: true,
             // only check the "reference" rect for changes
             sticky: 'reference',
-            // only check the "popper" rect for changes
-            // sticky: 'popper',
 
             arrow: false,
             offset: offset,


### PR DESCRIPTION
Use lib from jsdelivr (previously from unpkg) and bump
  - popperjs from 2.5.4 to 2.9.2
  - tippy.js from 6.2.7 to 6.3.1

Also use the bpmn-visualization API to set css classes on bpmn elements. This
ensures they are always applied if we activate diagram navigation.
Remove non relevant comments and commented code.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/chore/bump_3rd_party_lib_in_popover_example/examples/index.html