### PR TITLE
[FEAT] Improve the 'monitoring' demo

### DIFF
--- a/demo/monitoring-all-process-instances/execution-data.js
+++ b/demo/monitoring-all-process-instances/execution-data.js
@@ -102,26 +102,29 @@ function getShapeTimeData() {
 
 function getEdgeTimeData() {
     const overlayStyles = getTimeOverlayStyles('middle', '#c61700');
+    function getEdgeTimeOverlay() {
+        return getTimeOverlay('second', overlayStyles);
+    }
 
     const map = new Map();
-    map.set('sequence_flow_1', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_2', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_18', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_3', getTimeOverlay('minute', overlayStyles));
-    map.set('sequence_flow_4', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_12', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_13', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_5', getTimeOverlay('minute', overlayStyles));
-    map.set('sequence_flow_6', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_8', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_7', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_10', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_9', getTimeOverlay('minute', overlayStyles));
-    map.set('sequence_flow_11', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_14', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_15', getTimeOverlay('minute', overlayStyles));
-    map.set('sequence_flow_16', getTimeOverlay('second', overlayStyles));
-    map.set('sequence_flow_17', getTimeOverlay('second', overlayStyles));
+    map.set('sequence_flow_1', getEdgeTimeOverlay());
+    map.set('sequence_flow_2', getEdgeTimeOverlay());
+    map.set('sequence_flow_18', getEdgeTimeOverlay());
+    map.set('sequence_flow_3', getEdgeTimeOverlay());
+    map.set('sequence_flow_4', getEdgeTimeOverlay());
+    map.set('sequence_flow_12', getEdgeTimeOverlay());
+    map.set('sequence_flow_13', getEdgeTimeOverlay());
+    map.set('sequence_flow_5', getEdgeTimeOverlay());
+    map.set('sequence_flow_6', getEdgeTimeOverlay());
+    map.set('sequence_flow_8', getEdgeTimeOverlay());
+    map.set('sequence_flow_7', getEdgeTimeOverlay());
+    map.set('sequence_flow_10', getEdgeTimeOverlay());
+    map.set('sequence_flow_9', getEdgeTimeOverlay());
+    map.set('sequence_flow_11', getEdgeTimeOverlay());
+    map.set('sequence_flow_14', getEdgeTimeOverlay());
+    map.set('sequence_flow_15', getEdgeTimeOverlay());
+    map.set('sequence_flow_16', getEdgeTimeOverlay());
+    map.set('sequence_flow_17', getEdgeTimeOverlay());
     return map;
 }
 

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -57,12 +57,15 @@ limitations under the License.
     </section>
 </header>
 
-<section class="container col-10" style="margin-top: 3rem">
+<section class="container col-10 flex-centered mt-2">
+    <section class="col-12 mt-2">
     <div class="col-11 col-mx-auto">
-        <div class="h2">Monitoring of all process instances demo</div>
+        <h2>Monitoring of all process instances demo</h2>
+        <p>Demonstrate how you can add execution time and frequency on BPMN elements.
+        </p>
 
         <div class="col-12 pt-2">
-            <div id="controls" class="col-12" style="margin-top: 1rem; margin-bottom: 2rem">
+            <div id="controls" class="col-12" style="margin-bottom: 1rem">
                 <div id="switch-panel" class="switch switch--horizontal switch--expanding-inner">
                     <input id="btn-time" type="radio" name="switch-data-type" checked="checked"/>
                     <label for="btn-time">Time</label>
@@ -81,6 +84,7 @@ limitations under the License.
             </div>
         </div>
     </div>
+    </section>
 </section>
 
 <script src="../../examples/static/js/link-to-sources.js"></script>

--- a/demo/monitoring-all-process-instances/index.js
+++ b/demo/monitoring-all-process-instances/index.js
@@ -14,7 +14,8 @@ function loadData(bpmnVisualization, getData) {
     });
 }
 
-function switchDiagram(switchValue, frequencyBpmnVisualization, frequencyBpmnDiagramIsAlreadyLoad) {
+let frequencyBpmnDiagramIsAlreadyLoad = false;
+function switchDiagram(switchValue, frequencyBpmnVisualization) {
     // Display corresponding BPMN container & Hide others
     const bpmnContainers = document.getElementsByClassName("bpmn-container");
     for (let i = 0; i < bpmnContainers.length; i++) {
@@ -37,10 +38,9 @@ loadData(timeBpmnVisualization, getTimeData);
 
 // Initialize BpmnVisualization for Frequency Data
 const frequencyBpmnVisualization = initBpmnVisualization('frequency-bpmn-container');
-let frequencyBpmnDiagramIsAlreadyLoad = false;
 
 document.getElementById('switch-panel').onclick = () => {
     let switchId = document.querySelector("input[type='radio'][name='switch-data-type']:checked").id;
-    switchDiagram(switchId==='btn-time'? 'time' : 'frequency', frequencyBpmnVisualization, frequencyBpmnDiagramIsAlreadyLoad);
+    switchDiagram(switchId==='btn-time'? 'time' : 'frequency', frequencyBpmnVisualization);
 }
 


### PR DESCRIPTION
Add a short text in the page to explain what the example shows.

fix: don't reload the frequency diagram on every toggle
fix: display links to source code

Reduce execution time displayed in edge overlays - only use seconds. This
simulates the latency of the bpmn engine (time taken to process subsequent
element of the process instance) which should be close to 0.


covers https://github.com/process-analytics/bpmn-visualization-js/issues/1174

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/improve_demo_process-monitoring/examples/index.html
