### PR TITLE
[FIX] Fix overlay fill color in the Frequency monitoring demo

### DIFF
--- a/demo/monitoring-all-process-instances/execution-data.js
+++ b/demo/monitoring-all-process-instances/execution-data.js
@@ -137,17 +137,18 @@ function getFrequencyOverlayStyles(position, color) {
                 font: { color: 'White' },
             })
         }],
-        ['fivePerCent', {
+        ['ninetyFivePerCent', {
             position,
             style: withStrokeColorAsFillColor({
                 fill: { color: `rgba(${new Values(color).tint(21).rgb})` },
                 font: { color: 'White' },
             })
         }],
-        ['ninetyFivePerCent', {
+        ['otherPerCent', {
             position,
             style: withStrokeColorAsFillColor({
                 fill: { color: `rgba(${new Values(color).tint(42).rgb})` },
+                font: { color: 'White' },
             })
         }],
         ['thirtyPerCent', {
@@ -156,7 +157,7 @@ function getFrequencyOverlayStyles(position, color) {
                 fill: { color: `rgba(${new Values(color).tint(63).rgb})` },
             })
         }],
-        ['otherPerCent', {
+        ['fivePerCent', {
             position,
             style: withStrokeColorAsFillColor({
                 fill: { color: `rgba(${new Values(color).tint(84).rgb})` },


### PR DESCRIPTION
**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix_demo_monitoring/examples/index.html


The darker colors correspond to the higher numbers, and the lighter colors to the smaller numbers.

### Old version
![image](https://user-images.githubusercontent.com/4921914/121889536-a5889400-cd19-11eb-9b44-fb314b24de11.png)

### New version
![image](https://user-images.githubusercontent.com/4921914/121889501-9c97c280-cd19-11eb-9969-b17e665710cc.png)
