### PR TITLE
[FEAT] Bump bpmn-js from 8.6.0 to 8.7.1 used in the comparison example

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -119,7 +119,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.6.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-MN1oDmM+1LML43aqHuPxp7T9TdiDCKcgvCWAkfB5BiM=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.7.1/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-9lFOUedWSYPHv99e53vfrYJBtsbORXflcvMde1c237E=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.17.1/dist/bpmn-visualization.min.js"></script>
 


### PR DESCRIPTION
Note: as in #190, I tried to bump `kie-editors` but the 0.11.0 fails at initialization and BPMN load time.


**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/infra/bump_bpmn-js_competitor_lib_version/examples/index.html