### PR TITLE
[FIX] Update the label size for the legends in the monitoring demo

### DIFF
--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -117,7 +117,7 @@ limitations under the License.
         }
 
         #legend guide-y .tick .label {
-            width: 70px;
+            width: 80px;
         }
 
         #legend guide-y.left {


### PR DESCRIPTION
To support the different size of policies on the different OS