### PR TITLE
[FEAT] Update navigation example - let use scrollbars for panning

### DIFF
--- a/examples/diagram-navigation/diagram-navigation/README.md
+++ b/examples/diagram-navigation/diagram-navigation/README.md
@@ -18,3 +18,11 @@ new bpmnvisu.BpmnVisualization(
 );
 bpmnVisualizationNavigation.load(bpmnDiagram());
 ```
+
+### Scrollbars
+
+The `overflow` CSS property of the bpmn-container defines if scrollbars are used to display the BPMN diagram.
+For values of `auto` or `scroll`, the scrollbars will be shown.
+
+In this example, the scrollbars appear on toggle of the `overflow` CSS property from `hidden` (use the regular panning) to `auto`. In this case, the diagram can be moved
+by both using the scrollbars or the panning.

--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -69,7 +69,9 @@ limitations under the License.
                     <button id="btn-reset" title="Reset Zoom and Pan" class="btn btn-primary has-icon-right">
                         <span>Reset </span><span class="icon icon-refresh mb-1"></span>
                     </button>
-                    <button id="btn-toggle-scrollbars">bars</button>
+                    <button id="btn-toggle-scrollbars" title="Toggle usage of scrollbars" class="btn btn-secondary has-icon-right">
+                        <span>Scrollbars </span><span class="icon icon-apps mb-1"></span>
+                    </button>
                     <div id="bpmn-container" class="bpmn-container"></div>
                 </div>
             </section>

--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -69,6 +69,7 @@ limitations under the License.
                     <button id="btn-reset" title="Reset Zoom and Pan" class="btn btn-primary has-icon-right">
                         <span>Reset </span><span class="icon icon-refresh mb-1"></span>
                     </button>
+                    <button id="btn-toggle-scrollbars">bars</button>
                     <div id="bpmn-container" class="bpmn-container"></div>
                 </div>
             </section>

--- a/examples/diagram-navigation/diagram-navigation/index.js
+++ b/examples/diagram-navigation/diagram-navigation/index.js
@@ -3,6 +3,11 @@ bpmnVisualization.load(getNavigationBpmnDiagram());
 
 document.getElementById('btn-reset').onclick = function() {
   bpmnVisualization.fit({type: bpmnvisu.FitType.None});
+
+  if(displayScrollBars){
+    // reset scrollbars position
+    document.getElementById('bpmn-container').scrollTo(0, 0);
+  }
 };
 
 function resetZoomLevel() {

--- a/examples/diagram-navigation/diagram-navigation/index.js
+++ b/examples/diagram-navigation/diagram-navigation/index.js
@@ -1,41 +1,22 @@
-const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true } });
+const bpmnContainer = document.getElementById('bpmn-container');
+const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: bpmnContainer, navigation: { enabled: true } });
 bpmnVisualization.load(getNavigationBpmnDiagram());
 
-document.getElementById('btn-reset').onclick = function() {
-  bpmnVisualization.fit({type: bpmnvisu.FitType.None});
+let displayScrollBars = false;
+document.getElementById('btn-reset').onclick = function () {
+  bpmnVisualization.fit({ type: bpmnvisu.FitType.None });
 
-  if(displayScrollBars){
-    // reset scrollbars position
-    document.getElementById('bpmn-container').scrollTo(0, 0);
-  }
+  // reset scrollbars position
+  displayScrollBars && bpmnContainer.scrollTo(0, 0);
 };
 
-function resetZoomLevel() {
-  bpmnVisualization.fit({type: bpmnvisu.FitType.None});
-}
-
-// function loadInNewInstance() {
-//   const instance = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true } });
-// instance.load(getNavigationBpmnDiagram());
-// return instance;
-// }
-
-let displayScrollBars = false;
-document.getElementById('btn-toggle-scrollbars').onclick = function() {
+document.getElementById('btn-toggle-scrollbars').onclick = function () {
   displayScrollBars = !displayScrollBars;
 
-  document.getElementById('bpmn-container').style.overflow = displayScrollBars ? 'auto' : 'hidden';
-  // If default (true) value is used, the regular panning is not used, so
-  // if previous panning occured this can prevent to see the diagram
-  // bpmnVisualization.graph.useScrollbarsForPanning = false;
-  
-  // resetZoomLevel();
+  bpmnContainer.style.overflow = displayScrollBars ? 'auto' : 'hidden';
 
-  // ensure that all diagram positions are recomputed
+  // ensure that all diagram positions are recomputed (mainly for no scrollbars)
   bpmnVisualization.load(getNavigationBpmnDiagram());
-
-
-  //bpmnVisualization = loadInNewInstance();
 };
 
 

--- a/examples/diagram-navigation/diagram-navigation/index.js
+++ b/examples/diagram-navigation/diagram-navigation/index.js
@@ -5,6 +5,15 @@ document.getElementById('btn-reset').onclick = function() {
   bpmnVisualization.fit({type: bpmnvisu.FitType.None});
 };
 
+function resetZoomLevel() {
+  bpmnVisualization.fit({type: bpmnvisu.FitType.None});
+}
+
+// function loadInNewInstance() {
+//   const instance = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true } });
+// instance.load(getNavigationBpmnDiagram());
+// return instance;
+// }
 
 let displayScrollBars = false;
 document.getElementById('btn-toggle-scrollbars').onclick = function() {
@@ -14,6 +23,14 @@ document.getElementById('btn-toggle-scrollbars').onclick = function() {
   // If default (true) value is used, the regular panning is not used, so
   // if previous panning occured this can prevent to see the diagram
   // bpmnVisualization.graph.useScrollbarsForPanning = false;
+  
+  // resetZoomLevel();
+
+  // ensure that all diagram positions are recomputed
+  bpmnVisualization.load(getNavigationBpmnDiagram());
+
+
+  //bpmnVisualization = loadInNewInstance();
 };
 
 

--- a/examples/diagram-navigation/diagram-navigation/index.js
+++ b/examples/diagram-navigation/diagram-navigation/index.js
@@ -1,8 +1,19 @@
-console.info('je suis la')
-
 const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container', navigation: { enabled: true } });
 bpmnVisualization.load(getNavigationBpmnDiagram());
 
 document.getElementById('btn-reset').onclick = function() {
   bpmnVisualization.fit({type: bpmnvisu.FitType.None});
 };
+
+
+let displayScrollBars = false;
+document.getElementById('btn-toggle-scrollbars').onclick = function() {
+  displayScrollBars = !displayScrollBars;
+
+  document.getElementById('bpmn-container').style.overflow = displayScrollBars ? 'auto' : 'hidden';
+  // If default (true) value is used, the regular panning is not used, so
+  // if previous panning occured this can prevent to see the diagram
+  // bpmnVisualization.graph.useScrollbarsForPanning = false;
+};
+
+


### PR DESCRIPTION
The example now let choose panning without or with scrollbars.

closes #23 
closes https://github.com/process-analytics/bpmn-visualization-js/issues/735

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/23-navigate_with_scrollbars/examples/index.html