### PR TITLE
[FEAT] Monitoring demo: Change legend colors for time data

### DIFF
--- a/demo/monitoring-all-process-instances/js/execution-data/time-execution-data.js
+++ b/demo/monitoring-all-process-instances/js/execution-data/time-execution-data.js
@@ -1,7 +1,7 @@
 class TimeExecutionData extends ExecutionData {
 
     constructor() {
-        super('#008700', '#c61700');
+        super('#800000', '#008080');
     }
 
 


### PR DESCRIPTION
Avoid usage of green and red which are dedicated to signal OK/KO states.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/monitoring_demo/change_legend_colors_for_time_data/examples/index.html

![image](https://user-images.githubusercontent.com/4921914/133056282-69472d0b-1948-4dfd-89d0-1b3e7bfb31e9.png)

Before
![image](https://user-images.githubusercontent.com/27200110/133058540-0e179adc-0aff-40ce-96fd-62eef8d1322a.png)



Covers #204