### PR TITLE
[REFACTOR] Remove usage of mxgraph.mxConstants in examples

### DIFF
--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -107,6 +107,7 @@ limitations under the License.
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.19.1/dist/bpmn-visualization.min.js"></script>
 <!-- load the example -->
 <script src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
+<script src="../../examples/static/js/style-identifiers.js"></script>
 <script src="../static/js/use-case.js"></script>
 <script src="js/theme.js"></script>
 <script src="js/theme-bpmn-visualization.js"></script>

--- a/demo/hacktoberfest-custom-themes/js/theme-bpmn-visualization.js
+++ b/demo/hacktoberfest-custom-themes/js/theme-bpmn-visualization.js
@@ -12,48 +12,48 @@ class ThemeBpmnVisualization extends bpmnvisu.BpmnVisualization {
 
         // START EVENT
         let style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_START];
-        style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = this._theme.startEvent.stroke;
+        style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.startEvent.stroke;
         if (this._theme.startEvent.fill) {
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.startEvent.fill;
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.startEvent.fill;
         }
 
         // END EVENT
         style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_END];
-        style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = this._theme.endEvent.stroke;
-        style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.endEvent.fill;
+        style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.endEvent.stroke;
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.endEvent.fill;
         if (this._theme.endEvent.gradient) {
-            style[bpmnvisu.mxConstants.STYLE_GRADIENT_DIRECTION] = bpmnvisu.mxConstants.DIRECTION_WEST;
-            style[bpmnvisu.mxConstants.STYLE_GRADIENTCOLOR] = this._theme.endEvent.gradient;
+            style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_WEST;
+            style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = this._theme.endEvent.gradient;
         }
 
         // USER TASK
         style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.TASK_USER];
-        style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.userTask.fill;
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.userTask.fill;
         if (this._theme.userTask.font) {
-            style[bpmnvisu.mxConstants.STYLE_FONTCOLOR] = this._theme.userTask.font;
+            style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.userTask.font;
         }
 
         // EXCLUSIVE GATEWAY
         if (this._theme.exclusiveGateway.fill) {
             style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.GATEWAY_EXCLUSIVE];
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.exclusiveGateway.fill;
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.exclusiveGateway.fill;
         }
 
         // CALL ACTIVITY
         style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.CALL_ACTIVITY];
-        style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.callActivity.fill;
-        style[bpmnvisu.mxConstants.STYLE_FONTCOLOR] = this._theme.callActivity.font;
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.callActivity.fill;
+        style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.callActivity.font;
         if (this._theme.callActivity.stroke) {
-            style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = this._theme.callActivity.stroke;
+            style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.callActivity.stroke;
         }
 
         // POOL
         style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.POOL];
-        style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = this._theme.pool.labelFill;
-        style[bpmnvisu.mxConstants.STYLE_SWIMLANE_FILLCOLOR] = this._theme.pool.swimlaneFill;
-        style[bpmnvisu.mxConstants.STYLE_FONTSIZE] = 16;
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.pool.labelFill;
+        style[StyleIdentifiers.STYLE_SWIMLANE_FILLCOLOR] = this._theme.pool.swimlaneFill;
+        style[StyleIdentifiers.STYLE_FONTSIZE] = 16;
         if (this._theme.pool.font) {
-            style[bpmnvisu.mxConstants.STYLE_FONTCOLOR] = this._theme.pool.font;
+            style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.pool.font;
         }
     }
 

--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -26,8 +26,8 @@ StyleDefault.DEFAULT_FONT_COLOR = 'Cyan';
 const originalConfigureCommonDefaultStyle = StyleConfigurator.configureCommonDefaultStyle;
 StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'LemonChiffon';
-    style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'Orange';
+    style[mxConstants.STYLE_FILLCOLOR] = 'LemonChiffon';
+    style[mxConstants.STYLE_STROKECOLOR] = 'Orange';
 }
 ```
 
@@ -45,17 +45,17 @@ class BpmnVisualizationCustomColors extends BpmnVisualization {
 
         ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'Pink';
+            style[mxConstants.STYLE_FILLCOLOR] = 'Pink';
         });
 
         ShapeUtil.taskKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[bpmnvisu.mxConstants.STYLE_GRADIENT_DIRECTION] = bpmnvisu.mxConstants.DIRECTION_EAST;
-            style[bpmnvisu.mxConstants.STYLE_GRADIENTCOLOR] = 'White';
+            style[mxConstants.STYLE_GRADIENT_DIRECTION] = mxConstants.DIRECTION_EAST;
+            style[mxConstants.STYLE_GRADIENTCOLOR] = 'White';
         });
 
         const poolStyle = styleSheet.styles[ShapeBpmnElementKind.POOL];
-        poolStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'PaleGreen';
+        poolStyle[mxConstants.STYLE_FILLCOLOR] = 'PaleGreen';
     }
 }
 
@@ -75,11 +75,11 @@ class BpmnVisualizationCustomEventColors extends BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const startEventStyle = styleSheet.styles[ShapeBpmnElementKind.EVENT_START];
-        startEventStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = '#d6eea5';
+        startEventStyle[mxConstants.STYLE_FILLCOLOR] = '#d6eea5';
 
         [ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW].forEach(kind => {
             const intermediateEventStyle = styleSheet.styles[kind];
-            intermediateEventStyle[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = '#7307df';
+            intermediateEventStyle[mxConstants.STYLE_STROKECOLOR] = '#7307df';
         })
     }
 }
@@ -99,7 +99,7 @@ class BpmnVisualizationCustomColorsUserTask extends BpmnVisualization {
     configureStyle() {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
         const style = styleSheet.styles[ShapeBpmnElementKind.TASK_USER];
-        style[bpmnvisu.mxConstants.STYLE_FONTCOLOR] = '#2b992a';
+        style[mxConstants.STYLE_FONTCOLOR] = '#2b992a';
    }
 }
 

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -67,6 +67,7 @@ limitations under the License.
     <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.19.1/dist/bpmn-visualization.min.js"></script>
     <!-- load the example -->
     <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script src="../../static/js/style-identifiers.js"></script>
     <script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-bpmn-theme/custom-colors/index.js
+++ b/examples/custom-bpmn-theme/custom-colors/index.js
@@ -25,8 +25,8 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = originalDefaultFontColor;
 const originalConfigureCommonDefaultStyle = bpmnvisu.StyleConfigurator.configureCommonDefaultStyle;
 bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'LemonChiffon';
-    style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'Orange';
+    style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
 }
 
 const bpmnVisualizationCustomDefaultColor = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-colors' });
@@ -51,28 +51,28 @@ class BpmnVisualizationCustomColors extends bpmnvisu.BpmnVisualization {
 
         bpmnvisu.ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'Pink';
-            style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'FireBrick';
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = 'Pink';
+            style[StyleIdentifiers.STYLE_STROKECOLOR] = 'FireBrick';
         });
 
         bpmnvisu.ShapeUtil.taskKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[bpmnvisu.mxConstants.STYLE_GRADIENT_DIRECTION] = bpmnvisu.mxConstants.DIRECTION_EAST;
-            style[bpmnvisu.mxConstants.STYLE_GRADIENTCOLOR] = 'White';
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'Lavender';
-            style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'DarkBlue';
+            style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_EAST;
+            style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = 'White';
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = 'Lavender';
+            style[StyleIdentifiers.STYLE_STROKECOLOR] = 'DarkBlue';
         });
 
         bpmnvisu.ShapeUtil.gatewayKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'LightGoldenrodYellow';
-            style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'DarkOrange';
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LightGoldenrodYellow';
+            style[StyleIdentifiers.STYLE_STROKECOLOR] = 'DarkOrange';
         });
 
         const poolStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.POOL];
-        poolStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'PaleGreen';
-        poolStyle[bpmnvisu.mxConstants.STYLE_GRADIENT_DIRECTION] = bpmnvisu.mxConstants.DIRECTION_SOUTH;
-        poolStyle[bpmnvisu.mxConstants.STYLE_GRADIENTCOLOR] = 'White';
+        poolStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'PaleGreen';
+        poolStyle[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_SOUTH;
+        poolStyle[StyleIdentifiers.STYLE_GRADIENTCOLOR] = 'White';
     }
 
 }
@@ -95,21 +95,21 @@ class BpmnVisualizationCustomEventColors extends bpmnvisu.BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const startEventStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_START];
-        startEventStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = '#d6eea5';
-        startEventStyle[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = '#8dc125';
+        startEventStyle[StyleIdentifiers.STYLE_FILLCOLOR] = '#d6eea5';
+        startEventStyle[StyleIdentifiers.STYLE_STROKECOLOR] = '#8dc125';
 
         [bpmnvisu.ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, bpmnvisu.ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW].forEach(kind => {
             const intermediateEventStyle = styleSheet.styles[kind];
-            intermediateEventStyle[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = '#7307df';
+            intermediateEventStyle[StyleIdentifiers.STYLE_STROKECOLOR] = '#7307df';
         })
 
         const boundaryEventStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_BOUNDARY];
-        boundaryEventStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'LightGoldenrodYellow';
-        boundaryEventStyle[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'DarkOrange';
+        boundaryEventStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LightGoldenrodYellow';
+        boundaryEventStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'DarkOrange';
 
         const endEventStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_END];
-        endEventStyle[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'Pink';
-        endEventStyle[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'FireBrick';
+        endEventStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'Pink';
+        endEventStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'FireBrick';
     }
 
 }
@@ -131,11 +131,11 @@ class BpmnVisualizationCustomColorsUserTask extends bpmnvisu.BpmnVisualization {
     configureStyle() {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
         const style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.TASK_USER];
-        style[bpmnvisu.mxConstants.STYLE_FONTCOLOR] = '#2b992a';
-        style[bpmnvisu.mxConstants.STYLE_GRADIENT_DIRECTION] = bpmnvisu.mxConstants.DIRECTION_WEST;
-        style[bpmnvisu.mxConstants.STYLE_GRADIENTCOLOR] = 'White';
-        style[bpmnvisu.mxConstants.STYLE_FILLCOLOR] = 'Lavender';
-        style[bpmnvisu.mxConstants.STYLE_STROKECOLOR] = 'Red';
+        style[StyleIdentifiers.STYLE_FONTCOLOR] = '#2b992a';
+        style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_WEST;
+        style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = 'White';
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = 'Lavender';
+        style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Red';
    }
 }
 

--- a/examples/custom-bpmn-theme/custom-fonts/README.md
+++ b/examples/custom-bpmn-theme/custom-fonts/README.md
@@ -27,7 +27,7 @@ Content:
 ```javascript
 StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[bpmnvisu.mxConstants.STYLE_FONTSTYLE] = bpmnvisu.mxConstants.FONT_ITALIC;
+    style[mxConstants.STYLE_FONTSTYLE] = mxConstants.FONT_ITALIC;
 }
 ```
 
@@ -44,9 +44,9 @@ class BpmnVisualizationCustomFonts extends BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const userTaskStyle = styleSheet.styles[ShapeBpmnElementKind.TASK_USER];
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTFAMILY] = 'Courier New,serif';
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTSIZE] = '14';
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTSTYLE] = bpmnvisu.mxConstants.FONT_BOLD + bpmnvisu.mxConstants.FONT_ITALIC;
+        userTaskStyle[mxConstants.STYLE_FONTFAMILY] = 'Courier New,serif';
+        userTaskStyle[mxConstants.STYLE_FONTSIZE] = '14';
+        userTaskStyle[mxConstants.STYLE_FONTSTYLE] = mxConstants.FONT_BOLD + mxConstants.FONT_ITALIC;
     }
 }
 

--- a/examples/custom-bpmn-theme/custom-fonts/index.html
+++ b/examples/custom-bpmn-theme/custom-fonts/index.html
@@ -64,6 +64,7 @@ limitations under the License.
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.19.1/dist/bpmn-visualization.min.js"></script>
 <!-- load the example -->
 <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
+<script src="../../static/js/style-identifiers.js"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-bpmn-theme/custom-fonts/index.js
+++ b/examples/custom-bpmn-theme/custom-fonts/index.js
@@ -19,7 +19,7 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
 const originalConfigureCommonDefaultStyle = bpmnvisu.StyleConfigurator.configureCommonDefaultStyle;
 bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[bpmnvisu.mxConstants.STYLE_FONTSTYLE] = bpmnvisu.mxConstants.FONT_ITALIC;
+    style[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
 }
 
 const bpmnVisualizationCustomDefaultFont = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-font' });
@@ -45,14 +45,14 @@ class BpmnVisualizationCustomFonts extends bpmnvisu.BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const userTaskStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.TASK_USER];
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTFAMILY] = 'Courier New,serif';
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTSIZE] = '14';
-        userTaskStyle[bpmnvisu.mxConstants.STYLE_FONTSTYLE] = bpmnvisu.mxConstants.FONT_BOLD + bpmnvisu.mxConstants.FONT_ITALIC;
+        userTaskStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+        userTaskStyle[StyleIdentifiers.STYLE_FONTSIZE] = '14';
+        userTaskStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_BOLD + FontStyle.FONT_ITALIC;
 
         const poolStyle = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.POOL];
-        poolStyle[bpmnvisu.mxConstants.STYLE_FONTFAMILY] = 'MS Gothic,Courier New,serif';
-        poolStyle[bpmnvisu.mxConstants.STYLE_FONTSIZE] = '20';
-        poolStyle[bpmnvisu.mxConstants.STYLE_FONTSTYLE] = bpmnvisu.mxConstants.FONT_BOLD;
+        poolStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'MS Gothic,Courier New,serif';
+        poolStyle[StyleIdentifiers.STYLE_FONTSIZE] = '20';
+        poolStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_BOLD;
     }
 
 }

--- a/examples/static/js/style-identifiers.js
+++ b/examples/static/js/style-identifiers.js
@@ -1,0 +1,34 @@
+/**
+ * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ */
+class StyleIdentifiers {
+    static STYLE_FILLCOLOR = 'fillColor';
+    static STYLE_STROKECOLOR = 'strokeColor';
+
+    static STYLE_GRADIENT_DIRECTION = 'gradientDirection';
+    static STYLE_GRADIENTCOLOR = 'gradientColor';
+
+    static STYLE_FONTCOLOR = 'fontColor';
+    static STYLE_FONTFAMILY = 'fontFamily';
+    static STYLE_FONTSIZE = 'fontSize';
+    static STYLE_FONTSTYLE = 'fontStyle';
+
+    static STYLE_SWIMLANE_FILLCOLOR = 'swimlaneFillColor';
+}
+
+/**
+ * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ */
+class Directions {
+    static DIRECTION_EAST = 'east';
+    static DIRECTION_SOUTH = 'south';
+    static DIRECTION_WEST = 'west';
+}
+
+/**
+ * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ */
+class FontStyle {
+    static FONT_BOLD = 1;
+    static FONT_ITALIC = 2;
+}


### PR DESCRIPTION
The bpmn-visualization IIFE bundle will not export mxConstants in the future
as it is not part of our code. This had been done temporarily to keep examples
working.
The examples now use helper classes to access to the style string identifiers in
replacement of mxConstants.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/refactor/remove_usage_of_mxgraph_mxconstants/examples/index.html