### PR TITLE
[FEAT] Bump kie-editors-standalone in the comparison example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -666,7 +666,7 @@ limitations under the License.
                                     <img src="static/img/preview/misc/compare-with-kie-editors-standalone.png" class="img-responsive" alt="compare with kie-editors-standalone">
                                 </div>
                                 <div class="card-body">Compare the libraries on BPMN elements rendering and API usage.<br>
-                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (29 MB, more than 5 MB after compression)
+                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (12 MB, more than 2.5 MB after compression)
                                     and slow to initialize.</div>
                                 <div class="card-footer"></div>
                             </div>

--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -12,9 +12,9 @@ This example let you compare [bpmn-visualization](https://github.com/process-ana
 - API usage
 
 **WARN** \
-The following applies at least to `kie-editors-standalone@0.9.0`
-- The javascript bundle is very large (29 MB, more than 5 MB after compression), very slow to load and generates a lot of error in the console.
-- It is unable to display most of the C.x diagrams from the miwg-test-suite (parsing errors).
+The following applies at least to `kie-editors-standalone@0.13.0`
+- The javascript bundle is very large (12 MB, more than 2.5 MB after compression), very slow to load and generates a lot of error in the console.
+- It is unable to display most of the C.x diagrams from the miwg-test-suite (parsing errors). See also [KOGITO-5395](https://issues.redhat.com/browse/KOGITO-5395).
 
 
 ## Implementation notes

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -121,7 +121,7 @@ limitations under the License.
 <script src="../../static/js/link-to-sources.js"></script>
 <script src="../../static/js/dom-helper.js"></script>
 <!-- load bpmn kie-editors-standalone -->
-<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.9.0/dist/bpmn/index.js" integrity="sha256-H1nZXun5ICKj3MrVTfiT7cM7neoeC8UYUnTB6ustrZk=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.13.0/dist/bpmn/index.js" integrity="sha256-gg52khcKzv/5xzHFM80xnaWSxjtOmBm6NO1c4763Xtk=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.19.4/dist/bpmn-visualization.min.js"></script>
 


### PR DESCRIPTION
Bump from 0.9.0 to 0.13.0.
Also configure the `onError` hook and manage `setContent` returned promise to
better demonstrate the API usage.

closes #217
closes #218

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/45de4151/examples/misc/compare-with-kie-editors-standalone/index.html

