### PR TITLE
[FEAT] 'Predictions' demo: reduce visibility of already executed paths

### DIFF
--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -13,23 +13,17 @@
 
     /* message flow start marker */
 .bpmn-message-flow.state-already-executed > ellipse,
-    /* message flow line */
-.bpmn-message-flow.state-already-executed > path:nth-child(2),
-    /* message flow arrow */
-.bpmn-message-flow.state-already-executed > path:nth-child(4),
-    /* sequence flow line */
-.bpmn-sequence-flow.state-already-executed > path:nth-child(2),
-    /* sequence flow arrow */
-.bpmn-sequence-flow.state-already-executed > path:nth-child(3),
+    /* message flow line and arrow */
+.bpmn-message-flow.state-already-executed > path,
+    /* sequence flow line and arrow */
+.bpmn-sequence-flow.state-already-executed > path,
     /* task */
 .bpmn-task.state-already-executed > rect,
-    /* parallel gateway stroke */
-.bpmn-parallel-gateway.state-already-executed > path:nth-child(1),
-    /* parallel gateway icon */
-.bpmn-parallel-gateway.state-already-executed > path:nth-child(2),
-    /* start event icon */
-.bpmn-start-event.state-already-executed > rect:nth-child(2),
-.bpmn-start-event.state-already-executed > path:nth-child(4),
+    /* parallel gateway stroke and icon */
+.bpmn-parallel-gateway.state-already-executed > path,
+    /* message start event icon */
+.bpmn-start-event.state-already-executed > rect,
+.bpmn-start-event.state-already-executed > path,
     /* start event stroke */
 .bpmn-start-event.state-already-executed > ellipse {
     filter: blur(2px);

--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -1,0 +1,45 @@
+:root {
+    --color-path-executed: #aea3a3;;
+}
+
+    /* parallel gateway icon */
+.bpmn-parallel-gateway.state-already-executed > path:nth-child(2),
+    /* message flow arrow */
+.bpmn-message-flow.state-already-executed > path:nth-child(4),
+    /* sequence flow arrow */
+.bpmn-sequence-flow.state-already-executed > path:nth-child(3) {
+    fill: var(--color-path-executed);
+}
+
+    /* message flow start marker */
+.bpmn-message-flow.state-already-executed > ellipse,
+    /* message flow line */
+.bpmn-message-flow.state-already-executed > path:nth-child(2),
+    /* message flow arrow */
+.bpmn-message-flow.state-already-executed > path:nth-child(4),
+    /* sequence flow line */
+.bpmn-sequence-flow.state-already-executed > path:nth-child(2),
+    /* sequence flow arrow */
+.bpmn-sequence-flow.state-already-executed > path:nth-child(3),
+    /* task */
+.bpmn-task.state-already-executed > rect,
+    /* parallel gateway stroke */
+.bpmn-parallel-gateway.state-already-executed > path:nth-child(1),
+    /* parallel gateway icon */
+.bpmn-parallel-gateway.state-already-executed > path:nth-child(2),
+    /* start event icon */
+.bpmn-start-event.state-already-executed > rect:nth-child(2),
+.bpmn-start-event.state-already-executed > path:nth-child(4),
+    /* start event stroke */
+.bpmn-start-event.state-already-executed > ellipse {
+    filter: blur(2px);
+    stroke: var(--color-path-executed);
+}
+
+    /* labels (the selector applies to all div, not the only one that contains text, but this is ok.
+     Use important to override the color set inline in the style attribute of the label div */
+.bpmn-label.state-already-executed > g div {
+    color: var(--color-path-executed) !important;
+    /*or use opacity if we want to be able to read labels*/
+    filter: blur(1px);
+}

--- a/demo/predictions/index.html
+++ b/demo/predictions/index.html
@@ -24,6 +24,7 @@ limitations under the License.
     <link rel="stylesheet" href="../static/css/controls.css" type="text/css">
     <link rel="stylesheet" href="../static/css/use-case.css" type="text/css">
     <link rel="stylesheet" href="../static/css/bpmn-container.css" type="text/css">
+    <link rel="stylesheet" href="./css/demo.css" type="text/css">
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.20.0/dist/bpmn-visualization.min.js"></script>

--- a/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
+++ b/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
@@ -2,387 +2,392 @@
 
 // inspired from the BPMN specification example 'triso - Order Process for Pizza V4.bpmn'
 function pizzaDiagram() {
-    return `<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
-<semantic:definitions id="_1275940932088" targetNamespace="http://www.trisotech.com/definitions/_1275940932088" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL">
-    <semantic:message id="_1275940932310"/>
-    <semantic:message id="_1275940932433"/>
-    <semantic:process isExecutable="false" id="_6-1">
-        <semantic:laneSet id="ls_6-438">
-            <semantic:lane name="clerk" id="_6-650">
-                <semantic:flowNodeRef>_6-450</semantic:flowNodeRef>
-                <semantic:flowNodeRef>_6-652</semantic:flowNodeRef>
-                <semantic:flowNodeRef>_6-674</semantic:flowNodeRef>
-                <semantic:flowNodeRef>_6-695</semantic:flowNodeRef>
-            </semantic:lane>
-            <semantic:lane name="pizza chef" id="_6-446">
-                <semantic:flowNodeRef>_6-463</semantic:flowNodeRef>
-            </semantic:lane>
-            <semantic:lane name="delivery boy" id="_6-448">
-                <semantic:flowNodeRef>_6-514</semantic:flowNodeRef>
-                <semantic:flowNodeRef>_6-565</semantic:flowNodeRef>
-                <semantic:flowNodeRef>_6-616</semantic:flowNodeRef>
-            </semantic:lane>
-        </semantic:laneSet>
-        <semantic:startEvent name="Order received" id="_6-450">
-            <semantic:outgoing>_6-630</semantic:outgoing>
-            <semantic:messageEventDefinition messageRef="_1275940932310"/>
-        </semantic:startEvent>
-        <semantic:parallelGateway gatewayDirection="Unspecified" name="" id="_6-652">
-            <semantic:incoming>_6-630</semantic:incoming>
-            <semantic:outgoing>_6-691</semantic:outgoing>
-            <semantic:outgoing>_6-693</semantic:outgoing>
-        </semantic:parallelGateway>
-        <semantic:intermediateCatchEvent parallelMultiple="false" name="&#8222;where is my pizza?&#8220;" id="_6-674">
-            <semantic:incoming>_6-691</semantic:incoming>
-            <semantic:incoming>_6-746</semantic:incoming>
-            <semantic:outgoing>_6-748</semantic:outgoing>
-            <semantic:messageEventDefinition messageRef="_1275940932433"/>
-        </semantic:intermediateCatchEvent>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Calm customer" id="_6-695">
-            <semantic:incoming>_6-748</semantic:incoming>
-            <semantic:outgoing>_6-746</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Bake the pizza" id="_6-463">
-            <semantic:incoming>_6-693</semantic:incoming>
-            <semantic:outgoing>_6-632</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Deliver the pizza" id="_6-514">
-            <semantic:incoming>_6-632</semantic:incoming>
-            <semantic:outgoing>_6-634</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Receive payment" id="_6-565">
-            <semantic:incoming>_6-634</semantic:incoming>
-            <semantic:outgoing>_6-636</semantic:outgoing>
-        </semantic:task>
-        <semantic:endEvent name="" id="_6-616">
-            <semantic:incoming>_6-636</semantic:incoming>
-            <semantic:terminateEventDefinition/>
-        </semantic:endEvent>
-        <semantic:sequenceFlow sourceRef="_6-450" targetRef="_6-652" name="" id="_6-630"/>
-        <semantic:sequenceFlow sourceRef="_6-463" targetRef="_6-514" name="" id="_6-632"/>
-        <semantic:sequenceFlow sourceRef="_6-514" targetRef="_6-565" name="" id="_6-634"/>
-        <semantic:sequenceFlow sourceRef="_6-565" targetRef="_6-616" name="" id="_6-636"/>
-        <semantic:sequenceFlow sourceRef="_6-652" targetRef="_6-674" name="" id="_6-691"/>
-        <semantic:sequenceFlow sourceRef="_6-652" targetRef="_6-463" name="" id="_6-693"/>
-        <semantic:sequenceFlow sourceRef="_6-695" targetRef="_6-674" name="" id="_6-746"/>
-        <semantic:sequenceFlow sourceRef="_6-674" targetRef="_6-695" name="" id="_6-748"/>
-    </semantic:process>
-    <semantic:message id="_1275940932198"/>
-    <semantic:process isExecutable="false" id="_6-2">
-        <semantic:startEvent name="Hungry for pizza" id="_6-61">
-            <semantic:outgoing>_6-125</semantic:outgoing>
-        </semantic:startEvent>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Select a pizza" id="_6-74">
-            <semantic:incoming>_6-125</semantic:incoming>
-            <semantic:outgoing>_6-178</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Order a pizza" id="_6-127">
-            <semantic:incoming>_6-178</semantic:incoming>
-            <semantic:outgoing>_6-420</semantic:outgoing>
-        </semantic:task>
-        <semantic:eventBasedGateway eventGatewayType="Exclusive" instantiate="false" gatewayDirection="Unspecified" name="" id="_6-180">
-            <semantic:incoming>_6-420</semantic:incoming>
-            <semantic:incoming>_6-430</semantic:incoming>
-            <semantic:outgoing>_6-422</semantic:outgoing>
-            <semantic:outgoing>_6-424</semantic:outgoing>
-        </semantic:eventBasedGateway>
-        <semantic:intermediateCatchEvent parallelMultiple="false" name="pizza received" id="_6-202">
-            <semantic:incoming>_6-422</semantic:incoming>
-            <semantic:outgoing>_6-428</semantic:outgoing>
-            <semantic:messageEventDefinition messageRef="_1275940932198"/>
-        </semantic:intermediateCatchEvent>
-        <semantic:intermediateCatchEvent parallelMultiple="false" name="60 minutes" id="_6-219">
-            <semantic:incoming>_6-424</semantic:incoming>
-            <semantic:outgoing>_6-426</semantic:outgoing>
-            <semantic:timerEventDefinition>
-                <semantic:timeDate/>
-            </semantic:timerEventDefinition>
-        </semantic:intermediateCatchEvent>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Ask for the pizza" id="_6-236">
-            <semantic:incoming>_6-426</semantic:incoming>
-            <semantic:outgoing>_6-430</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Pay the pizza" id="_6-304">
-            <semantic:incoming>_6-428</semantic:incoming>
-            <semantic:outgoing>_6-434</semantic:outgoing>
-        </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Eat the pizza" id="_6-355">
-            <semantic:incoming>_6-434</semantic:incoming>
-            <semantic:outgoing>_6-436</semantic:outgoing>
-        </semantic:task>
-        <semantic:endEvent name="Hunger satisfied" id="_6-406">
-            <semantic:incoming>_6-436</semantic:incoming>
-        </semantic:endEvent>
-        <semantic:sequenceFlow sourceRef="_6-61" targetRef="_6-74" name="" id="_6-125"/>
-        <semantic:sequenceFlow sourceRef="_6-74" targetRef="_6-127" name="" id="_6-178"/>
-        <semantic:sequenceFlow sourceRef="_6-127" targetRef="_6-180" name="" id="_6-420"/>
-        <semantic:sequenceFlow sourceRef="_6-180" targetRef="_6-202" name="" id="_6-422"/>
-        <semantic:sequenceFlow sourceRef="_6-180" targetRef="_6-219" name="" id="_6-424"/>
-        <semantic:sequenceFlow sourceRef="_6-219" targetRef="_6-236" name="" id="_6-426"/>
-        <semantic:sequenceFlow sourceRef="_6-202" targetRef="_6-304" name="" id="_6-428"/>
-        <semantic:sequenceFlow sourceRef="_6-236" targetRef="_6-180" name="" id="_6-430"/>
-        <semantic:sequenceFlow sourceRef="_6-304" targetRef="_6-355" name="" id="_6-434"/>
-        <semantic:sequenceFlow sourceRef="_6-355" targetRef="_6-406" name="" id="_6-436"/>
-    </semantic:process>
-    <semantic:collaboration id="C1275940932557">
-        <semantic:participant name="Pizza Customer" processRef="_6-2" id="_6-53"/>
-        <semantic:participant name="Pizza vendor" processRef="_6-1" id="_6-438"/>
-        <semantic:messageFlow name="pizza order" sourceRef="_6-127" targetRef="_6-450" id="_6-638"/>
-        <semantic:messageFlow name="" sourceRef="_6-236" targetRef="_6-674" id="_6-642"/>
-        <semantic:messageFlow name="receipt" sourceRef="_6-565" targetRef="_6-304" id="_6-646"/>
-        <semantic:messageFlow name="money" sourceRef="_6-304" targetRef="_6-565" id="_6-648"/>
-        <semantic:messageFlow name="pizza" sourceRef="_6-514" targetRef="_6-202" id="_6-640"/>
-        <semantic:messageFlow name="" sourceRef="_6-695" targetRef="_6-236" id="_6-750"/>
-    </semantic:collaboration>
-    <bpmndi:BPMNDiagram documentation="" id="Trisotech.Visio-_6" name="Untitled Diagram" resolution="96.00000267028808">
-        <bpmndi:BPMNPlane bpmnElement="C1275940932557">
-            <bpmndi:BPMNShape bpmnElement="_6-53" isHorizontal="true" id="Trisotech.Visio__6-53">
-                <dc:Bounds height="294.0" width="1044.0" x="12.0" y="12.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-438" isHorizontal="true" id="Trisotech.Visio__6-438">
-                <dc:Bounds height="372.0" width="906.0" x="12.0" y="372.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-650" isHorizontal="true" id="Trisotech.Visio__6__6-650">
-                <dc:Bounds height="114.0" width="875.0" x="42.0" y="372.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-446" isHorizontal="true" id="Trisotech.Visio__6__6-446">
-                <dc:Bounds height="114.0" width="875.0" x="42.0" y="486.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-448" isHorizontal="true" id="Trisotech.Visio__6__6-448">
-                <dc:Bounds height="109.0" width="875.0" x="42.0" y="600.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-450" id="Trisotech.Visio__6__6-450">
-                <dc:Bounds height="30.0" width="30.0" x="79.0" y="405.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-652" id="Trisotech.Visio__6__6-652">
-                <dc:Bounds height="42.0" width="42.0" x="140.0" y="399.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-674" id="Trisotech.Visio__6__6-674">
-                <dc:Bounds height="32.0" width="32.0" x="218.0" y="404.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-695" id="Trisotech.Visio__6__6-695">
-                <dc:Bounds height="68.0" width="83.0" x="286.0" y="386.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-463" id="Trisotech.Visio__6__6-463">
-                <dc:Bounds height="68.0" width="83.0" x="252.0" y="521.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-514" id="Trisotech.Visio__6__6-514">
-                <dc:Bounds height="68.0" width="83.0" x="464.0" y="629.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-565" id="Trisotech.Visio__6__6-565">
-                <dc:Bounds height="68.0" width="83.0" x="603.0" y="629.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-616" id="Trisotech.Visio__6__6-616">
-                <dc:Bounds height="32.0" width="32.0" x="722.0" y="647.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-61" id="Trisotech.Visio__6__6-61">
-                <dc:Bounds height="30.0" width="30.0" x="66.0" y="96.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-74" id="Trisotech.Visio__6__6-74">
-                <dc:Bounds height="68.0" width="83.0" x="145.0" y="77.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-127" id="Trisotech.Visio__6__6-127">
-                <dc:Bounds height="68.0" width="83.0" x="265.0" y="77.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-180" id="Trisotech.Visio__6__6-180">
-                <dc:Bounds height="42.0" width="42.0" x="378.0" y="90.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-202" id="Trisotech.Visio__6__6-202">
-                <dc:Bounds height="32.0" width="32.0" x="647.0" y="95.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-219" id="Trisotech.Visio__6__6-219">
-                <dc:Bounds height="32.0" width="32.0" x="448.0" y="184.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-236" id="Trisotech.Visio__6__6-236">
-                <dc:Bounds height="68.0" width="83.0" x="517.0" y="166.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-304" id="Trisotech.Visio__6__6-304">
-                <dc:Bounds height="68.0" width="83.0" x="726.0" y="77.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-355" id="Trisotech.Visio__6__6-355">
-                <dc:Bounds height="68.0" width="83.0" x="834.0" y="77.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_6-406" id="Trisotech.Visio__6__6-406">
-                <dc:Bounds height="32.0" width="32.0" x="956.0" y="95.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNShape>
-            <bpmndi:BPMNEdge bpmnElement="_6-640" messageVisibleKind="initiating" id="Trisotech.Visio__6__6-640">
-                <di:waypoint x="506.0" y="629.0"/>
-                <di:waypoint x="506.0" y="384.0"/>
-                <di:waypoint x="663.0" y="384.0"/>
-                <di:waypoint x="663.0" y="127.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-630" id="Trisotech.Visio__6__6-630">
-                <di:waypoint x="109.0" y="420.0"/>
-                <di:waypoint x="140.0" y="420.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-691" id="Trisotech.Visio__6__6-691">
-                <di:waypoint x="182.0" y="420.0"/>
-                <di:waypoint x="200.0" y="420.0"/>
-                <di:waypoint x="218.0" y="420.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-648" messageVisibleKind="initiating" id="Trisotech.Visio__6__6-648">
-                <di:waypoint x="754.0" y="145.0"/>
-                <di:waypoint x="754.0" y="408.0"/>
-                <di:waypoint x="630.0" y="408.0"/>
-                <di:waypoint x="631.0" y="629.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-422" id="Trisotech.Visio__6__6-422">
-                <di:waypoint x="420.0" y="111.0"/>
-                <di:waypoint x="438.0" y="111.0"/>
-                <di:waypoint x="647.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-646" messageVisibleKind="non_initiating" id="Trisotech.Visio__6__6-646">
-                <di:waypoint x="658.0" y="629.0"/>
-                <di:waypoint x="658.0" y="432.0"/>
-                <di:waypoint x="782.0" y="432.0"/>
-                <di:waypoint x="782.0" y="145.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-428" id="Trisotech.Visio__6__6-428">
-                <di:waypoint x="679.0" y="111.0"/>
-                <di:waypoint x="726.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-748" id="Trisotech.Visio__6__6-748">
-                <di:waypoint x="250.0" y="420.0"/>
-                <di:waypoint x="268.0" y="420.0"/>
-                <di:waypoint x="286.0" y="420.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-420" id="Trisotech.Visio__6__6-420">
-                <di:waypoint x="348.0" y="111.0"/>
-                <di:waypoint x="366.0" y="111.0"/>
-                <di:waypoint x="378.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-636" id="Trisotech.Visio__6__6-636">
-                <di:waypoint x="686.0" y="663.0"/>
-                <di:waypoint x="704.0" y="663.0"/>
-                <di:waypoint x="722.0" y="663.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-750" id="Trisotech.Visio__6__6-750">
-                <di:waypoint x="328.0" y="386.0"/>
-                <di:waypoint x="328.0" y="348.0"/>
-                <di:waypoint x="572.0" y="348.0"/>
-                <di:waypoint x="572.0" y="234.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-436" id="Trisotech.Visio__6__6-436">
-                <di:waypoint x="918.0" y="111.0"/>
-                <di:waypoint x="936.0" y="111.0"/>
-                <di:waypoint x="956.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-632" id="Trisotech.Visio__6__6-632">
-                <di:waypoint x="335.0" y="555.0"/>
-                <di:waypoint x="353.0" y="555.0"/>
-                <di:waypoint x="353.0" y="663.0"/>
-                <di:waypoint x="464.0" y="663.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-634" id="Trisotech.Visio__6__6-634">
-                <di:waypoint x="548.0" y="663.0"/>
-                <di:waypoint x="603.0" y="663.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-125" id="Trisotech.Visio__6__6-125">
-                <di:waypoint x="96.0" y="111.0"/>
-                <di:waypoint x="114.0" y="111.0"/>
-                <di:waypoint x="145.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-430" id="Trisotech.Visio__6__6-430">
-                <di:waypoint x="600.0" y="200.0"/>
-                <di:waypoint x="618.0" y="200.0"/>
-                <di:waypoint x="618.0" y="252.0"/>
-                <di:waypoint x="576.0" y="252.0"/>
-                <di:waypoint x="549.0" y="252.0"/>
-                <di:waypoint x="360.0" y="252.0"/>
-                <di:waypoint x="360.0" y="111.0"/>
-                <di:waypoint x="378.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-642" id="Trisotech.Visio__6__6-642">
-                <di:waypoint x="545.0" y="234.0"/>
-                <di:waypoint x="545.0" y="324.0"/>
-                <di:waypoint x="234.0" y="324.0"/>
-                <di:waypoint x="234.0" y="404.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-424" id="Trisotech.Visio__6__6-424">
-                <di:waypoint x="399.0" y="132.0"/>
-                <di:waypoint x="399.0" y="200.0"/>
-                <di:waypoint x="448.0" y="200.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-638" messageVisibleKind="initiating" id="Trisotech.Visio__6__6-638">
-                <di:waypoint x="306.0" y="145.0"/>
-                <di:waypoint x="306.0" y="252.0"/>
-                <di:waypoint x="94.0" y="252.0"/>
-                <di:waypoint x="94.0" y="405.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-426" id="Trisotech.Visio__6__6-426">
-                <di:waypoint x="480.0" y="200.0"/>
-                <di:waypoint x="498.0" y="200.0"/>
-                <di:waypoint x="517.0" y="200.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-693" id="Trisotech.Visio__6__6-693">
-                <di:waypoint x="161.0" y="441.0"/>
-                <di:waypoint x="161.0" y="556.0"/>
-                <di:waypoint x="252.0" y="555.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-178" id="Trisotech.Visio__6__6-178">
-                <di:waypoint x="228.0" y="111.0"/>
-                <di:waypoint x="265.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-746" id="Trisotech.Visio__6__6-746">
-                <di:waypoint x="370.0" y="420.0"/>
-                <di:waypoint x="386.0" y="420.0"/>
-                <di:waypoint x="386.0" y="474.0"/>
-                <di:waypoint x="191.0" y="474.0"/>
-                <di:waypoint x="191.0" y="420.0"/>
-                <di:waypoint x="218.0" y="420.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="_6-434" id="Trisotech.Visio__6__6-434">
-                <di:waypoint x="810.0" y="111.0"/>
-                <di:waypoint x="834.0" y="111.0"/>
-                <bpmndi:BPMNLabel/>
-            </bpmndi:BPMNEdge>
-        </bpmndi:BPMNPlane>
-    </bpmndi:BPMNDiagram>
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<semantic:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" id="_1275940932088" targetNamespace="http://www.trisotech.com/definitions/_1275940932088">
+  <semantic:message id="_1275940932310" />
+  <semantic:message id="_1275940932433" />
+  <semantic:process id="_6-1" isExecutable="false">
+    <semantic:laneSet id="ls_6-438">
+      <semantic:lane id="_6-650" name="clerk">
+        <semantic:flowNodeRef>_6-450</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-652</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-695</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-674</semantic:flowNodeRef>
+      </semantic:lane>
+      <semantic:lane id="_6-446" name="pizza chef">
+        <semantic:flowNodeRef>_6-463</semantic:flowNodeRef>
+      </semantic:lane>
+      <semantic:lane id="_6-448" name="delivery boy">
+        <semantic:flowNodeRef>_6-616</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-565</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-514</semantic:flowNodeRef>
+      </semantic:lane>
+    </semantic:laneSet>
+    <semantic:sequenceFlow id="_6-630" name="" sourceRef="_6-450" targetRef="_6-652" />
+    <semantic:sequenceFlow id="_6-632" name="" sourceRef="_6-463" targetRef="_6-514" />
+    <semantic:sequenceFlow id="_6-634" name="" sourceRef="_6-514" targetRef="_6-565" />
+    <semantic:sequenceFlow id="_6-636" name="" sourceRef="_6-565" targetRef="_6-616" />
+    <semantic:sequenceFlow id="_6-691" name="" sourceRef="_6-652" targetRef="_6-674" />
+    <semantic:sequenceFlow id="_6-693" name="" sourceRef="_6-652" targetRef="_6-463" />
+    <semantic:sequenceFlow id="_6-746" name="" sourceRef="_6-695" targetRef="_6-674" />
+    <semantic:sequenceFlow id="_6-748" name="" sourceRef="_6-674" targetRef="_6-695" />
+    <semantic:task id="_6-463" name="Bake the pizza">
+      <semantic:incoming>_6-693</semantic:incoming>
+      <semantic:outgoing>_6-632</semantic:outgoing>
+    </semantic:task>
+    <semantic:parallelGateway id="_6-652" name="">
+      <semantic:incoming>_6-630</semantic:incoming>
+      <semantic:outgoing>_6-691</semantic:outgoing>
+      <semantic:outgoing>_6-693</semantic:outgoing>
+    </semantic:parallelGateway>
+    <semantic:startEvent id="_6-450" name="Order received">
+      <semantic:outgoing>_6-630</semantic:outgoing>
+      <semantic:messageEventDefinition messageRef="_1275940932310" />
+    </semantic:startEvent>
+    <semantic:endEvent id="_6-616" name="">
+      <semantic:incoming>_6-636</semantic:incoming>
+      <semantic:terminateEventDefinition />
+    </semantic:endEvent>
+    <semantic:task id="_6-565" name="Receive payment">
+      <semantic:incoming>_6-634</semantic:incoming>
+      <semantic:outgoing>_6-636</semantic:outgoing>
+    </semantic:task>
+    <semantic:task id="_6-514" name="Deliver the pizza">
+      <semantic:incoming>_6-632</semantic:incoming>
+      <semantic:outgoing>_6-634</semantic:outgoing>
+    </semantic:task>
+    <semantic:task id="_6-695" name="Calm customer">
+      <semantic:incoming>_6-748</semantic:incoming>
+      <semantic:outgoing>_6-746</semantic:outgoing>
+    </semantic:task>
+    <semantic:intermediateCatchEvent id="_6-674" name="„where is my pizza?“">
+      <semantic:incoming>_6-691</semantic:incoming>
+      <semantic:incoming>_6-746</semantic:incoming>
+      <semantic:outgoing>_6-748</semantic:outgoing>
+      <semantic:messageEventDefinition messageRef="_1275940932433" />
+    </semantic:intermediateCatchEvent>
+  </semantic:process>
+  <semantic:message id="_1275940932198" />
+  <semantic:process id="_6-2" isExecutable="false">
+    <semantic:eventBasedGateway id="_6-180" name="">
+      <semantic:incoming>_6-420</semantic:incoming>
+      <semantic:incoming>_6-430</semantic:incoming>
+      <semantic:outgoing>_6-422</semantic:outgoing>
+      <semantic:outgoing>_6-424</semantic:outgoing>
+    </semantic:eventBasedGateway>
+    <semantic:intermediateCatchEvent id="_6-202" name="pizza received">
+      <semantic:incoming>_6-422</semantic:incoming>
+      <semantic:outgoing>_6-428</semantic:outgoing>
+      <semantic:messageEventDefinition messageRef="_1275940932198" />
+    </semantic:intermediateCatchEvent>
+    <semantic:intermediateCatchEvent id="_6-219" name="60 minutes">
+      <semantic:incoming>_6-424</semantic:incoming>
+      <semantic:outgoing>_6-426</semantic:outgoing>
+      <semantic:timerEventDefinition>
+        <semantic:timeDate />
+      </semantic:timerEventDefinition>
+    </semantic:intermediateCatchEvent>
+    <semantic:task id="_6-236" name="Ask for the pizza">
+      <semantic:incoming>_6-426</semantic:incoming>
+      <semantic:outgoing>_6-430</semantic:outgoing>
+    </semantic:task>
+    <semantic:task id="_6-304" name="Pay the pizza">
+      <semantic:incoming>_6-428</semantic:incoming>
+      <semantic:outgoing>_6-434</semantic:outgoing>
+    </semantic:task>
+    <semantic:task id="_6-355" name="Eat the pizza">
+      <semantic:incoming>_6-434</semantic:incoming>
+      <semantic:outgoing>_6-436</semantic:outgoing>
+    </semantic:task>
+    <semantic:endEvent id="_6-406" name="Hunger satisfied">
+      <semantic:incoming>_6-436</semantic:incoming>
+    </semantic:endEvent>
+    <semantic:task id="_6-127" name="Order a pizza">
+      <semantic:incoming>_6-178</semantic:incoming>
+      <semantic:outgoing>_6-420</semantic:outgoing>
+    </semantic:task>
+    <semantic:task id="_6-74" name="Select a pizza">
+      <semantic:incoming>_6-125</semantic:incoming>
+      <semantic:outgoing>_6-178</semantic:outgoing>
+    </semantic:task>
+    <semantic:startEvent id="_6-61" name="Hungry for pizza">
+      <semantic:outgoing>_6-125</semantic:outgoing>
+    </semantic:startEvent>
+    <semantic:sequenceFlow id="_6-436" name="" sourceRef="_6-355" targetRef="_6-406" />
+    <semantic:sequenceFlow id="_6-434" name="" sourceRef="_6-304" targetRef="_6-355" />
+    <semantic:sequenceFlow id="_6-430" name="" sourceRef="_6-236" targetRef="_6-180" />
+    <semantic:sequenceFlow id="_6-428" name="" sourceRef="_6-202" targetRef="_6-304" />
+    <semantic:sequenceFlow id="_6-426" name="" sourceRef="_6-219" targetRef="_6-236" />
+    <semantic:sequenceFlow id="_6-424" name="" sourceRef="_6-180" targetRef="_6-219" />
+    <semantic:sequenceFlow id="_6-422" name="" sourceRef="_6-180" targetRef="_6-202" />
+    <semantic:sequenceFlow id="_6-420" name="" sourceRef="_6-127" targetRef="_6-180" />
+    <semantic:sequenceFlow id="_6-178" name="" sourceRef="_6-74" targetRef="_6-127" />
+    <semantic:sequenceFlow id="_6-125" name="" sourceRef="_6-61" targetRef="_6-74" />
+  </semantic:process>
+  <semantic:collaboration id="C1275940932557">
+    <semantic:participant id="_6-53" name="Pizza Customer" processRef="_6-2" />
+    <semantic:participant id="_6-438" name="Pizza vendor" processRef="_6-1" />
+    <semantic:messageFlow id="_6-638" name="pizza order" sourceRef="_6-127" targetRef="_6-450" />
+    <semantic:messageFlow id="_6-642" name="" sourceRef="_6-236" targetRef="_6-674" />
+    <semantic:messageFlow id="_6-646" name="receipt" sourceRef="_6-565" targetRef="_6-304" />
+    <semantic:messageFlow id="_6-648" name="money" sourceRef="_6-304" targetRef="_6-565" />
+    <semantic:messageFlow id="_6-640" name="pizza" sourceRef="_6-514" targetRef="_6-202" />
+    <semantic:messageFlow id="_6-750" name="" sourceRef="_6-695" targetRef="_6-236" />
+  </semantic:collaboration>
+  <bpmndi:BPMNDiagram id="Trisotech.Visio-_6" name="Untitled Diagram" documentation="" resolution="96.00000267028808">
+    <bpmndi:BPMNPlane bpmnElement="C1275940932557">
+      <bpmndi:BPMNShape id="Trisotech.Visio__6-53" bpmnElement="_6-53" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="1066" height="356" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-436" bpmnElement="_6-436">
+        <di:waypoint x="1088" y="241" />
+        <di:waypoint x="1106" y="241" />
+        <di:waypoint x="1126" y="241" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-434" bpmnElement="_6-434">
+        <di:waypoint x="980" y="241" />
+        <di:waypoint x="1004" y="241" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-430" bpmnElement="_6-430">
+        <di:waypoint x="770" y="330" />
+        <di:waypoint x="788" y="330" />
+        <di:waypoint x="788" y="400" />
+        <di:waypoint x="520" y="400" />
+        <di:waypoint x="520" y="241" />
+        <di:waypoint x="548" y="241" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-428" bpmnElement="_6-428">
+        <di:waypoint x="849" y="241" />
+        <di:waypoint x="896" y="241" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-426" bpmnElement="_6-426">
+        <di:waypoint x="650" y="330" />
+        <di:waypoint x="668" y="330" />
+        <di:waypoint x="687" y="330" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-424" bpmnElement="_6-424">
+        <di:waypoint x="569" y="262" />
+        <di:waypoint x="569" y="330" />
+        <di:waypoint x="618" y="330" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-422" bpmnElement="_6-422">
+        <di:waypoint x="590" y="241" />
+        <di:waypoint x="608" y="241" />
+        <di:waypoint x="817" y="241" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-420" bpmnElement="_6-420">
+        <di:waypoint x="518" y="190" />
+        <di:waypoint x="569" y="190" />
+        <di:waypoint x="569" y="220" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-178" bpmnElement="_6-178">
+        <di:waypoint x="398" y="190" />
+        <di:waypoint x="435" y="190" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-125" bpmnElement="_6-125">
+        <di:waypoint x="266" y="190" />
+        <di:waypoint x="315" y="190" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-180" bpmnElement="_6-180">
+        <dc:Bounds x="548" y="220" width="42" height="42" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-202" bpmnElement="_6-202">
+        <dc:Bounds x="817" y="225" width="32" height="32" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="798" y="203" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-219" bpmnElement="_6-219">
+        <dc:Bounds x="618" y="314" width="32" height="32" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="607" y="346" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-236" bpmnElement="_6-236">
+        <dc:Bounds x="687" y="296" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-304" bpmnElement="_6-304">
+        <dc:Bounds x="896" y="207" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-355" bpmnElement="_6-355">
+        <dc:Bounds x="1004" y="207" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-406" bpmnElement="_6-406">
+        <dc:Bounds x="1126" y="225" width="32" height="32" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1102" y="257" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-127" bpmnElement="_6-127">
+        <dc:Bounds x="435" y="156" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-74" bpmnElement="_6-74">
+        <dc:Bounds x="315" y="156" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-61" bpmnElement="_6-61">
+        <dc:Bounds x="236" y="175" width="30" height="30" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="213" y="216" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6-438" bpmnElement="_6-438" isHorizontal="true">
+        <dc:Bounds x="160" y="502" width="1066" height="372" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-448" bpmnElement="_6-448" isHorizontal="true">
+        <dc:Bounds x="190" y="730" width="1035" height="109" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-446" bpmnElement="_6-446" isHorizontal="true">
+        <dc:Bounds x="190" y="616" width="1035" height="114" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-650" bpmnElement="_6-650" isHorizontal="true">
+        <dc:Bounds x="190" y="502" width="1035" height="114" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-748" bpmnElement="_6-748">
+        <di:waypoint x="526" y="550" />
+        <di:waypoint x="687" y="550" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-746" bpmnElement="_6-746">
+        <di:waypoint x="770" y="550" />
+        <di:waypoint x="810" y="550" />
+        <di:waypoint x="810" y="604" />
+        <di:waypoint x="510" y="604" />
+        <di:waypoint x="510" y="566" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-693" bpmnElement="_6-693">
+        <di:waypoint x="331" y="571" />
+        <di:waypoint x="331" y="686" />
+        <di:waypoint x="422" y="685" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-691" bpmnElement="_6-691">
+        <di:waypoint x="352" y="550" />
+        <di:waypoint x="494" y="550" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-636" bpmnElement="_6-636">
+        <di:waypoint x="991" y="793" />
+        <di:waypoint x="1144" y="793" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-634" bpmnElement="_6-634">
+        <di:waypoint x="874" y="793" />
+        <di:waypoint x="908" y="793" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-632" bpmnElement="_6-632">
+        <di:waypoint x="505" y="685" />
+        <di:waypoint x="648" y="685" />
+        <di:waypoint x="648" y="793" />
+        <di:waypoint x="791" y="793" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-630" bpmnElement="_6-630">
+        <di:waypoint x="279" y="550" />
+        <di:waypoint x="310" y="550" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-450" bpmnElement="_6-450">
+        <dc:Bounds x="249" y="535" width="30" height="30" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="228" y="565" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-652" bpmnElement="_6-652">
+        <dc:Bounds x="310" y="529" width="42" height="42" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-463" bpmnElement="_6-463">
+        <dc:Bounds x="422" y="651" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-616" bpmnElement="_6-616">
+        <dc:Bounds x="1144" y="777" width="32" height="32" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-565" bpmnElement="_6-565">
+        <dc:Bounds x="908" y="759" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-514" bpmnElement="_6-514">
+        <dc:Bounds x="791" y="759" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-695" bpmnElement="_6-695">
+        <dc:Bounds x="687" y="516" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-674" bpmnElement="_6-674">
+        <dc:Bounds x="494" y="534" width="32" height="32" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="438" y="566" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640">
+        <di:waypoint x="833" y="759" />
+        <di:waypoint x="833" y="257" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="797" y="471" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-750" bpmnElement="_6-750">
+        <di:waypoint x="729" y="516" />
+        <di:waypoint x="729" y="364" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-642" bpmnElement="_6-642">
+        <di:waypoint x="715" y="364" />
+        <di:waypoint x="715" y="454" />
+        <di:waypoint x="510" y="454" />
+        <di:waypoint x="510" y="534" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-646" bpmnElement="_6-646">
+        <di:waypoint x="963" y="759" />
+        <di:waypoint x="963" y="275" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="973" y="537" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-648" bpmnElement="_6-648">
+        <di:waypoint x="924" y="275" />
+        <di:waypoint x="924" y="759" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="883" y="537" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-638" bpmnElement="_6-638">
+        <di:waypoint x="476" y="224" />
+        <di:waypoint x="476" y="382" />
+        <di:waypoint x="264" y="382" />
+        <di:waypoint x="264" y="535" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="343" y="357" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </semantic:definitions>`;
 }

--- a/demo/predictions/js/index.js
+++ b/demo/predictions/js/index.js
@@ -1,10 +1,9 @@
 // Initialize UseCases
-const predictedLateUseCase = new PredictionUseCase('late');
-const onTimeUseCase = new PredictionUseCase('onTime');
+const predictedLateUseCase = new PredicatedLateUseCase('late');
+const onTimeUseCase = new PredictedOnTimeUseCase('onTime');
 
 const state = {
     useCase: predictedLateUseCase,
-    dataType: 'both'
 }
 
 // Update state of radio buttons

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -1,6 +1,56 @@
-class PredictionUseCase extends UseCase {
+const alreadyExecutedElementsPredictedLate = [
+    // customer
+    '_6-61', // start event
+    '_6-125', // sequence flow between 'start event' and 'select pizza'
+    '_6-74', // select a pizza
+    '_6-178', // sequence flow between 'select a pizza' and 'order a pizza'
+    '_6-127', // order a pizza
+    '_6-420', // sequence flow between 'order a pizza' and 'event-based gateway' (running element)
+
+    '_6-638', // message flow
+
+    // vendor
+    '_6-450', // order received
+    '_6-630', // sequence flow between 'order received' and 'parallel gateway'
+    '_6-652', // parallel gateway
+    '_6-693', // sequence flow between 'parallel gateway' and 'Bake the pizza'
+];
+
+class PredicatedLateUseCase extends UseCase {
+    _alreadyExecutedElements;
 
     constructor(type) {
         super(type, () => pizzaDiagram(), true);
+        this._alreadyExecutedElements = alreadyExecutedElementsPredictedLate;
     }
+
+    display(dataType) {
+        super.display(dataType);
+        this._reduceVisibilityOfAlreadyExecutedElements();
+    }
+
+    _reduceVisibilityOfAlreadyExecutedElements() {
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(this._alreadyExecutedElements, 'state-already-executed');
+    }
+
+    // running elements
+    // '_6-180', // customer event based gateway
+    // '_6-463', // vendor 'Bake the pizza'
+}
+
+
+class PredictedOnTimeUseCase extends PredicatedLateUseCase {
+
+    constructor(type) {
+        super(type);
+        this._alreadyExecutedElements = [...alreadyExecutedElementsPredictedLate, ...[
+            // vendor
+            '_6-463', //'Bake the pizza'
+            '_6-632', // sequence flow between 'Bake the pizza' and 'Deliver the pizza'
+        ]];
+    }
+
+    // running elements
+    // '_6-180', // customer event based gateway
+    // '_6-514', // vendor 'Deliver the pizza'
 }

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -14,6 +14,7 @@ const alreadyExecutedElementsPredictedLate = [
     '_6-630', // sequence flow between 'order received' and 'parallel gateway'
     '_6-652', // parallel gateway
     '_6-693', // sequence flow between 'parallel gateway' and 'Bake the pizza'
+    '_6-691', // sequence flow between 'parallel gateway' and 'where is my pizza'
 ];
 
 class PredicatedLateUseCase extends UseCase {


### PR DESCRIPTION
Style the paths for the 2 use cases. We use very specific css selectors (at
least more precise than in already existing examples and demo).
It is also applied to the label but is only visible after zooming or panning
because of a bug in `bpmn-visualization`.

Improve the layout of the pizza diagram:
  - remove message flow icon: it is currently not possible to style for now with `bpmn-visualization@0.20.0`: https://github.com/process-analytics/bpmn-visualization-js/issues/1622)
  - align elements in pool to have vertical message flow (improve clarity)

closes #263 

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/263-style_executed_paths/demo/predictions/index.html


**Path styling for the 'predicted late' use case**
Same behaviour with the 'predicted on time' use case.
I choose to 'blur' the path. My idea is that we focus on running elements, we don't care about the past. But we want to have a visual information about the relative place of the running elements in the whole diagram.
When we will enrich the demo, we could add ways to remove the blur, or progressively hide the already executed elements (with an animation).

Notice that the labels are not styled on load. See https://github.com/process-analytics/bpmn-visualization-js/issues/1621.

On load | after zoom or pan
---------  | ------------------------
![prediction_demo_predicted_late_executed_elements_01_on_load](https://user-images.githubusercontent.com/27200110/142655574-c9ff36bf-461e-4cc8-a808-4216b3110365.png) | ![prediction_demo_predicted_late_executed_elements_02_label_styled](https://user-images.githubusercontent.com/27200110/142655579-87eb2fe7-f30e-4b6a-a7ee-4f8bc657ed7f.png)


