### PR TITLE
[FEAT] 'Predictions' demo: style elements that are in progress 

### DIFF
--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -1,5 +1,9 @@
 :root {
-    --color-path-executed: #aea3a3;;
+    --color-path-executed: #aea3a3;
+    --color-path-predicted-late: orange;
+    --color-state-predicted-late: orange;
+    --color-state-predicted-on-time: #a7f0a7;
+    --color-state-running: #9c9cef;
 }
 
     /* parallel gateway icon */
@@ -36,4 +40,90 @@
     color: var(--color-path-executed) !important;
     /*or use opacity if we want to be able to read labels*/
     filter: blur(1px);
+}
+
+/* ================================================================================================================== */
+/* INFO */
+/* ================================================================================================================== */
+
+/* only the surrounding path for event gateway, otherwise the diamond is darker (double fill) */
+.bpmn-event-based-gateway.state-running > path:nth-child(1),
+.bpmn-intermediate-catch-event.state-running > ellipse,
+/* envelope of the message event */
+.bpmn-intermediate-catch-event.state-running > rect {
+    fill: var(--color-state-running);
+}
+
+/*apply shadow on hover*/
+.bpmn-event-based-gateway.state-running:hover,
+.bpmn-intermediate-catch-event.state-running:hover {
+    filter: drop-shadow(0 0 0.5em rgba(0, 0, 0));
+}
+
+
+/* ================================================================================================================== */
+/* PREDICTED LATE */
+/* ================================================================================================================== */
+
+/*for filter drop-shadow: https://css-tricks.com/adding-shadows-to-svg-icons-with-css-and-svg-filters/*/
+/*for pulse animation: https://reactgo.com/css-pulse-animation/*/
+
+/* task */
+.bpmn-task.state-predicted-late > rect {
+    fill: var(--color-state-predicted-late);
+    animation: pulse-animation 2.5s infinite;
+}
+
+@keyframes pulse-animation {
+    0% {
+        fill-opacity: 100%;
+        filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0.8));
+    }
+    50% {
+        fill-opacity: 90%;
+        filter: drop-shadow(0 0 0.75em rgba(0, 0, 0));
+    }
+    100% {
+        fill-opacity: 100%;
+        filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0.8));
+    }
+}
+
+
+    /* sequence flow arrow */
+.bpmn-sequence-flow.path-predicted-late > path:nth-child(3) {
+    fill: var(--color-path-predicted-late);
+}
+
+    /* sequence flow line and arrow*/
+.bpmn-sequence-flow.path-predicted-late > path,
+    /* task */
+.bpmn-task.path-predicted-late > rect,
+    /* intermediate catch event icon */
+.bpmn-intermediate-catch-event.path-predicted-late > path,
+    /* intermediate catch event stroke */
+.bpmn-intermediate-catch-event.path-predicted-late > ellipse {
+    /*filter: blur(2px);*/
+    stroke: var(--color-path-predicted-late);
+/*    todo stroke size? */
+}
+
+/* labels (the selector applies to all div, not the only one that contains text, but this is ok.
+ Use important to override the color set inline in the style attribute of the label div */
+.bpmn-label.path-predicted-late > g div {
+    color: var(--color-path-predicted-late) !important;
+    /*TODO size?*/
+}
+
+/* ================================================================================================================== */
+/* PREDICTED ON TIME */
+/* ================================================================================================================== */
+
+.bpmn-task.state-predicted-on-time > rect {
+    fill: var(--color-state-predicted-on-time);
+}
+
+/*apply shadow on hover*/
+.bpmn-task.state-predicted-on-time:hover {
+    filter: drop-shadow(0 0 0.5em rgba(0, 0, 0));
 }

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -17,6 +17,11 @@ const alreadyExecutedElementsPredictedLate = [
     '_6-691', // sequence flow between 'parallel gateway' and 'where is my pizza'
 ];
 
+const vendorBakeThePizzaId = '_6-463';
+const vendorWhereIsMyPizzaId = '_6-674';
+const vendorDeliverThePizzaId = '_6-514';
+const customerEvtBasedGwId = '_6-180';
+
 class PredicatedLateUseCase extends UseCase {
     _alreadyExecutedElements;
 
@@ -28,15 +33,18 @@ class PredicatedLateUseCase extends UseCase {
     display(dataType) {
         super.display(dataType);
         this._reduceVisibilityOfAlreadyExecutedElements();
+        this._highlightPredictionOnRunningElements();
     }
 
     _reduceVisibilityOfAlreadyExecutedElements() {
         this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(this._alreadyExecutedElements, 'state-already-executed');
     }
 
-    // running elements
-    // '_6-180', // customer event based gateway
-    // '_6-463', // vendor 'Bake the pizza'
+    _highlightPredictionOnRunningElements() {
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(vendorBakeThePizzaId, 'state-predicted-late');
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses([vendorWhereIsMyPizzaId, customerEvtBasedGwId], 'state-running');
+    }
+
 }
 
 
@@ -46,12 +54,14 @@ class PredictedOnTimeUseCase extends PredicatedLateUseCase {
         super(type);
         this._alreadyExecutedElements = [...alreadyExecutedElementsPredictedLate, ...[
             // vendor
-            '_6-463', //'Bake the pizza'
+            vendorBakeThePizzaId, //'Bake the pizza'
             '_6-632', // sequence flow between 'Bake the pizza' and 'Deliver the pizza'
         ]];
     }
 
-    // running elements
-    // '_6-180', // customer event based gateway
-    // '_6-514', // vendor 'Deliver the pizza'
+    _highlightPredictionOnRunningElements() {
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(vendorDeliverThePizzaId, 'state-predicted-on-time');
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses([vendorWhereIsMyPizzaId, customerEvtBasedGwId], 'state-running');
+    }
+
 }


### PR DESCRIPTION
covers #261

Add a blur effect on hover for elements that will be actionable. A popover will
be available on click.
Add a 'pulse' effect on the 'predicated late' element. This signals that actions
are required.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/261_predictions_demo_highlight_running_elements/demo/predictions/index.html

### Implementation notes
I chose an arbitrary set of colors that could be changed. I suggest we don't do it now and we wait for now. It will be easier to update all colors when all elements of the demo will be integrated. Otherwise, I am afraid that we will change the colors in each PR.
hover on running task: exhibit bug in `bpmn-visualization` https://github.com/process-analytics/bpmn-visualization-js/issues/920

![PR_265_style_in_progress_elements](https://user-images.githubusercontent.com/27200110/142885897-273deed1-0b3d-4fc3-b81e-68708ea18dc8.gif)
