### PR TITLE
[FEAT] 'Predictions' demo: improve the 'pizza diagram'

### DIFF
--- a/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
+++ b/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
@@ -8,42 +8,44 @@ function pizzaDiagram() {
   <semantic:message id="_1275940932433" />
   <semantic:process id="_6-1" isExecutable="false">
     <semantic:laneSet id="ls_6-438">
-      <semantic:lane id="_6-650" name="clerk">
-        <semantic:flowNodeRef>_6-450</semantic:flowNodeRef>
-        <semantic:flowNodeRef>_6-652</semantic:flowNodeRef>
-        <semantic:flowNodeRef>_6-695</semantic:flowNodeRef>
-        <semantic:flowNodeRef>_6-674</semantic:flowNodeRef>
-      </semantic:lane>
-      <semantic:lane id="_6-446" name="pizza chef">
-        <semantic:flowNodeRef>_6-463</semantic:flowNodeRef>
-      </semantic:lane>
       <semantic:lane id="_6-448" name="delivery boy">
         <semantic:flowNodeRef>_6-616</semantic:flowNodeRef>
         <semantic:flowNodeRef>_6-565</semantic:flowNodeRef>
         <semantic:flowNodeRef>_6-514</semantic:flowNodeRef>
       </semantic:lane>
+      <semantic:lane id="_6-446" name="pizza chef">
+        <semantic:flowNodeRef>_6-463</semantic:flowNodeRef>
+      </semantic:lane>
+      <semantic:lane id="_6-650" name="clerk">
+        <semantic:flowNodeRef>_6-652</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-450</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-695</semantic:flowNodeRef>
+        <semantic:flowNodeRef>_6-674</semantic:flowNodeRef>
+      </semantic:lane>
     </semantic:laneSet>
-    <semantic:sequenceFlow id="_6-630" name="" sourceRef="_6-450" targetRef="_6-652" />
-    <semantic:sequenceFlow id="_6-632" name="" sourceRef="_6-463" targetRef="_6-514" />
-    <semantic:sequenceFlow id="_6-634" name="" sourceRef="_6-514" targetRef="_6-565" />
-    <semantic:sequenceFlow id="_6-636" name="" sourceRef="_6-565" targetRef="_6-616" />
-    <semantic:sequenceFlow id="_6-691" name="" sourceRef="_6-652" targetRef="_6-674" />
-    <semantic:sequenceFlow id="_6-693" name="" sourceRef="_6-652" targetRef="_6-463" />
-    <semantic:sequenceFlow id="_6-746" name="" sourceRef="_6-695" targetRef="_6-674" />
-    <semantic:sequenceFlow id="_6-748" name="" sourceRef="_6-674" targetRef="_6-695" />
-    <semantic:task id="_6-463" name="Bake the pizza">
-      <semantic:incoming>_6-693</semantic:incoming>
-      <semantic:outgoing>_6-632</semantic:outgoing>
-    </semantic:task>
     <semantic:parallelGateway id="_6-652" name="">
       <semantic:incoming>_6-630</semantic:incoming>
       <semantic:outgoing>_6-691</semantic:outgoing>
       <semantic:outgoing>_6-693</semantic:outgoing>
     </semantic:parallelGateway>
-    <semantic:startEvent id="_6-450" name="Order received">
+    <semantic:startEvent id="_6-450" name="Order&#10;received">
       <semantic:outgoing>_6-630</semantic:outgoing>
       <semantic:messageEventDefinition messageRef="_1275940932310" />
     </semantic:startEvent>
+    <semantic:task id="_6-695" name="Calm customer">
+      <semantic:incoming>_6-748</semantic:incoming>
+      <semantic:outgoing>_6-746</semantic:outgoing>
+    </semantic:task>
+    <semantic:intermediateCatchEvent id="_6-674" name="„where is my pizza?“">
+      <semantic:incoming>_6-691</semantic:incoming>
+      <semantic:incoming>_6-746</semantic:incoming>
+      <semantic:outgoing>_6-748</semantic:outgoing>
+      <semantic:messageEventDefinition messageRef="_1275940932433" />
+    </semantic:intermediateCatchEvent>
+    <semantic:task id="_6-463" name="Bake the pizza">
+      <semantic:incoming>_6-693</semantic:incoming>
+      <semantic:outgoing>_6-632</semantic:outgoing>
+    </semantic:task>
     <semantic:endEvent id="_6-616" name="">
       <semantic:incoming>_6-636</semantic:incoming>
       <semantic:terminateEventDefinition />
@@ -56,16 +58,14 @@ function pizzaDiagram() {
       <semantic:incoming>_6-632</semantic:incoming>
       <semantic:outgoing>_6-634</semantic:outgoing>
     </semantic:task>
-    <semantic:task id="_6-695" name="Calm customer">
-      <semantic:incoming>_6-748</semantic:incoming>
-      <semantic:outgoing>_6-746</semantic:outgoing>
-    </semantic:task>
-    <semantic:intermediateCatchEvent id="_6-674" name="„where is my pizza?“">
-      <semantic:incoming>_6-691</semantic:incoming>
-      <semantic:incoming>_6-746</semantic:incoming>
-      <semantic:outgoing>_6-748</semantic:outgoing>
-      <semantic:messageEventDefinition messageRef="_1275940932433" />
-    </semantic:intermediateCatchEvent>
+    <semantic:sequenceFlow id="_6-748" name="" sourceRef="_6-674" targetRef="_6-695" />
+    <semantic:sequenceFlow id="_6-746" name="" sourceRef="_6-695" targetRef="_6-674" />
+    <semantic:sequenceFlow id="_6-693" name="" sourceRef="_6-652" targetRef="_6-463" />
+    <semantic:sequenceFlow id="_6-691" name="" sourceRef="_6-652" targetRef="_6-674" />
+    <semantic:sequenceFlow id="_6-632" name="" sourceRef="_6-463" targetRef="_6-514" />
+    <semantic:sequenceFlow id="_6-630" name="" sourceRef="_6-450" targetRef="_6-652" />
+    <semantic:sequenceFlow id="_6-636" name="" sourceRef="_6-565" targetRef="_6-616" />
+    <semantic:sequenceFlow id="_6-634" name="" sourceRef="_6-514" targetRef="_6-565" />
   </semantic:process>
   <semantic:message id="_1275940932198" />
   <semantic:process id="_6-2" isExecutable="false">
@@ -113,14 +113,14 @@ function pizzaDiagram() {
     <semantic:startEvent id="_6-61" name="Hungry for pizza">
       <semantic:outgoing>_6-125</semantic:outgoing>
     </semantic:startEvent>
-    <semantic:sequenceFlow id="_6-436" name="" sourceRef="_6-355" targetRef="_6-406" />
-    <semantic:sequenceFlow id="_6-434" name="" sourceRef="_6-304" targetRef="_6-355" />
     <semantic:sequenceFlow id="_6-430" name="" sourceRef="_6-236" targetRef="_6-180" />
-    <semantic:sequenceFlow id="_6-428" name="" sourceRef="_6-202" targetRef="_6-304" />
-    <semantic:sequenceFlow id="_6-426" name="" sourceRef="_6-219" targetRef="_6-236" />
+    <semantic:sequenceFlow id="_6-420" name="" sourceRef="_6-127" targetRef="_6-180" />
     <semantic:sequenceFlow id="_6-424" name="" sourceRef="_6-180" targetRef="_6-219" />
     <semantic:sequenceFlow id="_6-422" name="" sourceRef="_6-180" targetRef="_6-202" />
-    <semantic:sequenceFlow id="_6-420" name="" sourceRef="_6-127" targetRef="_6-180" />
+    <semantic:sequenceFlow id="_6-428" name="" sourceRef="_6-202" targetRef="_6-304" />
+    <semantic:sequenceFlow id="_6-426" name="" sourceRef="_6-219" targetRef="_6-236" />
+    <semantic:sequenceFlow id="_6-434" name="" sourceRef="_6-304" targetRef="_6-355" />
+    <semantic:sequenceFlow id="_6-436" name="" sourceRef="_6-355" targetRef="_6-406" />
     <semantic:sequenceFlow id="_6-178" name="" sourceRef="_6-74" targetRef="_6-127" />
     <semantic:sequenceFlow id="_6-125" name="" sourceRef="_6-61" targetRef="_6-74" />
   </semantic:process>
@@ -137,255 +137,255 @@ function pizzaDiagram() {
   <bpmndi:BPMNDiagram id="Trisotech.Visio-_6" name="Untitled Diagram" documentation="" resolution="96.00000267028808">
     <bpmndi:BPMNPlane bpmnElement="C1275940932557">
       <bpmndi:BPMNShape id="Trisotech.Visio__6-53" bpmnElement="_6-53" isHorizontal="true">
-        <dc:Bounds x="160" y="80" width="1066" height="356" />
+        <dc:Bounds x="160" y="80" width="1050" height="295" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-436" bpmnElement="_6-436">
-        <di:waypoint x="1088" y="241" />
-        <di:waypoint x="1106" y="241" />
-        <di:waypoint x="1126" y="241" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-434" bpmnElement="_6-434">
-        <di:waypoint x="980" y="241" />
-        <di:waypoint x="1004" y="241" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-430" bpmnElement="_6-430">
-        <di:waypoint x="770" y="330" />
-        <di:waypoint x="788" y="330" />
-        <di:waypoint x="788" y="400" />
-        <di:waypoint x="520" y="400" />
-        <di:waypoint x="520" y="241" />
-        <di:waypoint x="548" y="241" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-428" bpmnElement="_6-428">
-        <di:waypoint x="849" y="241" />
-        <di:waypoint x="896" y="241" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-426" bpmnElement="_6-426">
-        <di:waypoint x="650" y="330" />
-        <di:waypoint x="668" y="330" />
-        <di:waypoint x="687" y="330" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-424" bpmnElement="_6-424">
-        <di:waypoint x="569" y="262" />
-        <di:waypoint x="569" y="330" />
-        <di:waypoint x="618" y="330" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-422" bpmnElement="_6-422">
-        <di:waypoint x="590" y="241" />
-        <di:waypoint x="608" y="241" />
-        <di:waypoint x="817" y="241" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-420" bpmnElement="_6-420">
-        <di:waypoint x="518" y="190" />
-        <di:waypoint x="569" y="190" />
-        <di:waypoint x="569" y="220" />
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-125" bpmnElement="_6-125">
+        <di:waypoint x="266" y="143" />
+        <di:waypoint x="315" y="143" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-178" bpmnElement="_6-178">
-        <di:waypoint x="398" y="190" />
-        <di:waypoint x="435" y="190" />
+        <di:waypoint x="398" y="143" />
+        <di:waypoint x="435" y="143" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-125" bpmnElement="_6-125">
-        <di:waypoint x="266" y="190" />
-        <di:waypoint x="315" y="190" />
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-436" bpmnElement="_6-436">
+        <di:waypoint x="1088" y="194" />
+        <di:waypoint x="1106" y="194" />
+        <di:waypoint x="1126" y="194" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-434" bpmnElement="_6-434">
+        <di:waypoint x="980" y="194" />
+        <di:waypoint x="1004" y="194" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-426" bpmnElement="_6-426">
+        <di:waypoint x="650" y="283" />
+        <di:waypoint x="668" y="283" />
+        <di:waypoint x="687" y="283" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-428" bpmnElement="_6-428">
+        <di:waypoint x="849" y="194" />
+        <di:waypoint x="896" y="194" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-422" bpmnElement="_6-422">
+        <di:waypoint x="590" y="194" />
+        <di:waypoint x="608" y="194" />
+        <di:waypoint x="817" y="194" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-424" bpmnElement="_6-424">
+        <di:waypoint x="569" y="215" />
+        <di:waypoint x="569" y="283" />
+        <di:waypoint x="618" y="283" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-420" bpmnElement="_6-420">
+        <di:waypoint x="518" y="143" />
+        <di:waypoint x="569" y="143" />
+        <di:waypoint x="569" y="173" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-430" bpmnElement="_6-430">
+        <di:waypoint x="770" y="283" />
+        <di:waypoint x="788" y="283" />
+        <di:waypoint x="788" y="344" />
+        <di:waypoint x="520" y="344" />
+        <di:waypoint x="520" y="194" />
+        <di:waypoint x="548" y="194" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-180" bpmnElement="_6-180">
-        <dc:Bounds x="548" y="220" width="42" height="42" />
+        <dc:Bounds x="548" y="173" width="42" height="42" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-202" bpmnElement="_6-202">
-        <dc:Bounds x="817" y="225" width="32" height="32" />
+        <dc:Bounds x="817" y="178" width="32" height="32" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="798" y="203" width="71" height="14" />
+          <dc:Bounds x="798" y="156" width="71" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-219" bpmnElement="_6-219">
-        <dc:Bounds x="618" y="314" width="32" height="32" />
+        <dc:Bounds x="618" y="267" width="32" height="32" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="607" y="346" width="54" height="14" />
+          <dc:Bounds x="607" y="299" width="54" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-236" bpmnElement="_6-236">
-        <dc:Bounds x="687" y="296" width="83" height="68" />
+        <dc:Bounds x="687" y="249" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-304" bpmnElement="_6-304">
-        <dc:Bounds x="896" y="207" width="83" height="68" />
+        <dc:Bounds x="896" y="160" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-355" bpmnElement="_6-355">
-        <dc:Bounds x="1004" y="207" width="83" height="68" />
+        <dc:Bounds x="1004" y="160" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-406" bpmnElement="_6-406">
-        <dc:Bounds x="1126" y="225" width="32" height="32" />
+        <dc:Bounds x="1126" y="178" width="32" height="32" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1102" y="257" width="80" height="14" />
+          <dc:Bounds x="1102" y="210" width="80" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-127" bpmnElement="_6-127">
-        <dc:Bounds x="435" y="156" width="83" height="68" />
+        <dc:Bounds x="435" y="109" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-74" bpmnElement="_6-74">
-        <dc:Bounds x="315" y="156" width="83" height="68" />
+        <dc:Bounds x="315" y="109" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-61" bpmnElement="_6-61">
-        <dc:Bounds x="236" y="175" width="30" height="30" />
+        <dc:Bounds x="236" y="128" width="30" height="30" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="213" y="216" width="81" height="14" />
+          <dc:Bounds x="213" y="169" width="81" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6-438" bpmnElement="_6-438" isHorizontal="true">
-        <dc:Bounds x="160" y="502" width="1066" height="372" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-448" bpmnElement="_6-448" isHorizontal="true">
-        <dc:Bounds x="190" y="730" width="1035" height="109" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-446" bpmnElement="_6-446" isHorizontal="true">
-        <dc:Bounds x="190" y="616" width="1035" height="114" />
+        <dc:Bounds x="160" y="422" width="1050" height="338" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-650" bpmnElement="_6-650" isHorizontal="true">
-        <dc:Bounds x="190" y="502" width="1035" height="114" />
+        <dc:Bounds x="190" y="422" width="1020" height="114" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-748" bpmnElement="_6-748">
-        <di:waypoint x="526" y="550" />
-        <di:waypoint x="687" y="550" />
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-446" bpmnElement="_6-446" isHorizontal="true">
+        <dc:Bounds x="190" y="536" width="1020" height="104" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-746" bpmnElement="_6-746">
-        <di:waypoint x="770" y="550" />
-        <di:waypoint x="810" y="550" />
-        <di:waypoint x="810" y="604" />
-        <di:waypoint x="510" y="604" />
-        <di:waypoint x="510" y="566" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-448" bpmnElement="_6-448" isHorizontal="true">
+        <dc:Bounds x="190" y="640" width="1020" height="120" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-693" bpmnElement="_6-693">
-        <di:waypoint x="331" y="571" />
-        <di:waypoint x="331" y="686" />
-        <di:waypoint x="422" y="685" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-691" bpmnElement="_6-691">
-        <di:waypoint x="352" y="550" />
-        <di:waypoint x="494" y="550" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-634" bpmnElement="_6-634">
+        <di:waypoint x="874" y="702" />
+        <di:waypoint x="908" y="702" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-636" bpmnElement="_6-636">
-        <di:waypoint x="991" y="793" />
-        <di:waypoint x="1144" y="793" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-634" bpmnElement="_6-634">
-        <di:waypoint x="874" y="793" />
-        <di:waypoint x="908" y="793" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-632" bpmnElement="_6-632">
-        <di:waypoint x="505" y="685" />
-        <di:waypoint x="648" y="685" />
-        <di:waypoint x="648" y="793" />
-        <di:waypoint x="791" y="793" />
+        <di:waypoint x="991" y="702" />
+        <di:waypoint x="1144" y="702" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-630" bpmnElement="_6-630">
-        <di:waypoint x="279" y="550" />
-        <di:waypoint x="310" y="550" />
+        <di:waypoint x="279" y="470" />
+        <di:waypoint x="310" y="470" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-632" bpmnElement="_6-632">
+        <di:waypoint x="505" y="590" />
+        <di:waypoint x="648" y="590" />
+        <di:waypoint x="648" y="702" />
+        <di:waypoint x="791" y="702" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-691" bpmnElement="_6-691">
+        <di:waypoint x="352" y="470" />
+        <di:waypoint x="494" y="470" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-693" bpmnElement="_6-693">
+        <di:waypoint x="331" y="491" />
+        <di:waypoint x="331" y="590" />
+        <di:waypoint x="422" y="590" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-746" bpmnElement="_6-746">
+        <di:waypoint x="770" y="470" />
+        <di:waypoint x="790" y="470" />
+        <di:waypoint x="790" y="524" />
+        <di:waypoint x="510" y="524" />
+        <di:waypoint x="510" y="486" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-748" bpmnElement="_6-748">
+        <di:waypoint x="526" y="470" />
+        <di:waypoint x="687" y="470" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-652" bpmnElement="_6-652">
+        <dc:Bounds x="310" y="449" width="42" height="42" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-450" bpmnElement="_6-450">
-        <dc:Bounds x="249" y="535" width="30" height="30" />
+        <dc:Bounds x="249" y="455" width="30" height="30" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="228" y="565" width="73" height="14" />
+          <dc:Bounds x="243" y="486" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-652" bpmnElement="_6-652">
-        <dc:Bounds x="310" y="529" width="42" height="42" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-463" bpmnElement="_6-463">
-        <dc:Bounds x="422" y="651" width="83" height="68" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-616" bpmnElement="_6-616">
-        <dc:Bounds x="1144" y="777" width="32" height="32" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-565" bpmnElement="_6-565">
-        <dc:Bounds x="908" y="759" width="83" height="68" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-514" bpmnElement="_6-514">
-        <dc:Bounds x="791" y="759" width="83" height="68" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-695" bpmnElement="_6-695">
-        <dc:Bounds x="687" y="516" width="83" height="68" />
+        <dc:Bounds x="687" y="436" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-674" bpmnElement="_6-674">
-        <dc:Bounds x="494" y="534" width="32" height="32" />
+        <dc:Bounds x="494" y="454" width="32" height="32" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="438" y="566" width="63" height="27" />
+          <dc:Bounds x="438" y="486" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640">
-        <di:waypoint x="833" y="759" />
-        <di:waypoint x="833" y="257" />
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-463" bpmnElement="_6-463">
+        <dc:Bounds x="422" y="556" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-616" bpmnElement="_6-616">
+        <dc:Bounds x="1144" y="686" width="32" height="32" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-565" bpmnElement="_6-565">
+        <dc:Bounds x="908" y="668" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Trisotech.Visio__6__6-514" bpmnElement="_6-514">
+        <dc:Bounds x="791" y="668" width="83" height="68" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-638" bpmnElement="_6-638">
+        <di:waypoint x="476" y="177" />
+        <di:waypoint x="476" y="302" />
+        <di:waypoint x="264" y="302" />
+        <di:waypoint x="264" y="455" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="797" y="471" width="26" height="14" />
+          <dc:Bounds x="343" y="283" width="55" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-750" bpmnElement="_6-750">
-        <di:waypoint x="729" y="516" />
-        <di:waypoint x="729" y="364" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-642" bpmnElement="_6-642">
-        <di:waypoint x="715" y="364" />
-        <di:waypoint x="715" y="454" />
+        <di:waypoint x="715" y="317" />
+        <di:waypoint x="715" y="400" />
+        <di:waypoint x="510" y="400" />
         <di:waypoint x="510" y="454" />
-        <di:waypoint x="510" y="534" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-646" bpmnElement="_6-646">
-        <di:waypoint x="963" y="759" />
-        <di:waypoint x="963" y="275" />
+        <di:waypoint x="963" y="668" />
+        <di:waypoint x="963" y="228" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="973" y="537" width="34" height="14" />
+          <dc:Bounds x="973" y="446" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-648" bpmnElement="_6-648">
-        <di:waypoint x="924" y="275" />
-        <di:waypoint x="924" y="759" />
+        <di:waypoint x="924" y="228" />
+        <di:waypoint x="924" y="668" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="883" y="537" width="34" height="14" />
+          <dc:Bounds x="883" y="446" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-638" bpmnElement="_6-638">
-        <di:waypoint x="476" y="224" />
-        <di:waypoint x="476" y="382" />
-        <di:waypoint x="264" y="382" />
-        <di:waypoint x="264" y="535" />
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640">
+        <di:waypoint x="833" y="668" />
+        <di:waypoint x="833" y="210" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="343" y="357" width="55" height="14" />
+          <dc:Bounds x="837" y="393" width="26" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-750" bpmnElement="_6-750">
+        <di:waypoint x="729" y="436" />
+        <di:waypoint x="729" y="317" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Limit blank on top
Remove extra lane on bottom
Reduce space between pools
Improve pool and lane width to avoid line overlapping

covers #261

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/261-improve_pizza_diagram/demo/predictions/index.html

**Screenshots done with bpmn-visualization@0.20.0**

before | after
------- | -------
![01_before](https://user-images.githubusercontent.com/27200110/142898658-b3b553f7-1e0b-4d60-863a-4c00d9309806.png) | ![02_after_improvements](https://user-images.githubusercontent.com/27200110/142898662-804580f6-d941-4ee2-87e3-c4ca655314cf.png)


