### PR TITLE
[FEAT] 'Predictions' demo: highlight predicted paths

### DIFF
--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -1,9 +1,12 @@
 :root {
+    --color-default-fill: white;
     --color-path-executed: #aea3a3;
     --color-path-predicted-late: orange;
     --color-state-predicted-late: orange;
+    --color-path-predicted-on-time: #67d567;
     --color-state-predicted-on-time: #a7f0a7;
     --color-state-running: #9c9cef;
+    --stroke-path-predicted: 0.18rem;
 }
 
     /* parallel gateway icon */
@@ -17,19 +20,17 @@
 
     /* message flow start marker */
 .bpmn-message-flow.state-already-executed > ellipse,
-    /* message flow line and arrow */
-.bpmn-message-flow.state-already-executed > path,
-    /* sequence flow line and arrow */
-.bpmn-sequence-flow.state-already-executed > path,
+    /* sequence/message flow line and arrow (end marker) */
+.bpmn-type-flow.state-already-executed > path,
     /* task */
-.bpmn-task.state-already-executed > rect,
+.bpmn-type-task.state-already-executed > rect,
     /* parallel gateway stroke and icon */
 .bpmn-parallel-gateway.state-already-executed > path,
-    /* message start event icon */
-.bpmn-start-event.state-already-executed > rect,
-.bpmn-start-event.state-already-executed > path,
-    /* start event stroke */
-.bpmn-start-event.state-already-executed > ellipse {
+    /* message event icon */
+.bpmn-event-def-message.state-already-executed > rect,
+.bpmn-event-def-message.state-already-executed > path,
+    /* event stroke */
+.bpmn-type-event.state-already-executed > ellipse {
     filter: blur(2px);
     stroke: var(--color-path-executed);
 }
@@ -46,17 +47,17 @@
 /* INFO */
 /* ================================================================================================================== */
 
-/* only the surrounding path for event gateway, otherwise the diamond is darker (double fill) */
-.bpmn-event-based-gateway.state-running > path:nth-child(1),
-.bpmn-intermediate-catch-event.state-running > ellipse,
+/* only the surrounding path of gateway, otherwise the diamond is darker (double fill) */
+.bpmn-type-gateway.state-running > path:nth-child(1),
+.bpmn-type-event.state-running > ellipse,
 /* envelope of the message event */
-.bpmn-intermediate-catch-event.state-running > rect {
+.bpmn-event-def-message.state-running > rect {
     fill: var(--color-state-running);
 }
 
 /*apply shadow on hover*/
-.bpmn-event-based-gateway.state-running:hover,
-.bpmn-intermediate-catch-event.state-running:hover {
+.bpmn-type-event.state-running:hover,
+.bpmn-type-gateway.state-running:hover {
     filter: drop-shadow(0 0 0.5em rgba(0, 0, 0));
 }
 
@@ -71,7 +72,7 @@
 /* task */
 .bpmn-task.state-predicted-late > rect {
     fill: var(--color-state-predicted-late);
-    animation: pulse-animation 2.5s infinite;
+    animation: pulse-animation 0.8s infinite alternate;
 }
 
 @keyframes pulse-animation {
@@ -79,51 +80,93 @@
         fill-opacity: 100%;
         filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0.8));
     }
-    50% {
+    100% {
         fill-opacity: 90%;
         filter: drop-shadow(0 0 0.75em rgba(0, 0, 0));
     }
-    100% {
-        fill-opacity: 100%;
-        filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0.8));
-    }
 }
 
-
+    /* message flow start marker */
+.bpmn-message-flow.path-predicted-late > ellipse,
     /* sequence flow arrow */
 .bpmn-sequence-flow.path-predicted-late > path:nth-child(3) {
     fill: var(--color-path-predicted-late);
 }
 
-    /* sequence flow line and arrow*/
-.bpmn-sequence-flow.path-predicted-late > path,
-    /* task */
-.bpmn-task.path-predicted-late > rect,
-    /* intermediate catch event icon */
-.bpmn-intermediate-catch-event.path-predicted-late > path,
-    /* intermediate catch event stroke */
-.bpmn-intermediate-catch-event.path-predicted-late > ellipse {
-    /*filter: blur(2px);*/
+    /* sequence/message flow line and arrow (end marker) */
+.bpmn-type-flow.path-predicted-late > path,
+    /* message flow start marker */
+.bpmn-message-flow.path-predicted-late > ellipse,
+.bpmn-type-gateway.path-predicted-late > path:nth-child(1),
+.bpmn-type-task.path-predicted-late > rect,
+.bpmn-type-event.path-predicted-late > ellipse {
     stroke: var(--color-path-predicted-late);
-/*    todo stroke size? */
+    stroke-width: var(--stroke-path-predicted);
+}
+
+.bpmn-type-gateway.path-predicted-late > path:nth-child(1),
+.bpmn-event-based-gateway.path-predicted-late > ellipse,
+.bpmn-event-based-gateway.path-predicted-late > path:nth-child(7),
+.bpmn-event-def-message.path-predicted-late > rect,
+.bpmn-event-def-message.path-predicted-late > path,
+.bpmn-event-def-timer.path-predicted-late > path,
+.bpmn-type-event.path-predicted-late > ellipse {
+    stroke: var(--color-path-predicted-late);
+    fill: var(--color-default-fill);
 }
 
 /* labels (the selector applies to all div, not the only one that contains text, but this is ok.
  Use important to override the color set inline in the style attribute of the label div */
 .bpmn-label.path-predicted-late > g div {
     color: var(--color-path-predicted-late) !important;
-    /*TODO size?*/
+    font-weight: bold;
 }
 
 /* ================================================================================================================== */
 /* PREDICTED ON TIME */
 /* ================================================================================================================== */
 
-.bpmn-task.state-predicted-on-time > rect {
+.bpmn-type-task.state-predicted-on-time > rect {
     fill: var(--color-state-predicted-on-time);
 }
 
 /*apply shadow on hover*/
-.bpmn-task.state-predicted-on-time:hover {
+.bpmn-type-task.state-predicted-on-time:hover {
     filter: drop-shadow(0 0 0.5em rgba(0, 0, 0));
+}
+
+/* message flow start marker */
+.bpmn-message-flow.path-predicted-on-time > ellipse,
+    /* sequence flow arrow */
+.bpmn-sequence-flow.path-predicted-on-time > path:nth-child(3) {
+    fill: var(--color-path-predicted-on-time);
+}
+
+.bpmn-type-gateway.path-predicted-on-time > path:nth-child(1),
+/* sequence/message flow line and arrow (end marker) */
+.bpmn-type-flow.path-predicted-on-time > path,
+    /* message flow start marker */
+.bpmn-message-flow.path-predicted-on-time > ellipse,
+.bpmn-type-task.path-predicted-on-time > rect,
+.bpmn-type-event.path-predicted-on-time > ellipse {
+    stroke: var(--color-path-predicted-on-time);
+    stroke-width: var(--stroke-path-predicted);
+}
+
+.bpmn-type-gateway.path-predicted-on-time > path:nth-child(1),
+.bpmn-event-based-gateway.path-predicted-on-time > ellipse,
+.bpmn-event-based-gateway.path-predicted-on-time > path:nth-child(7),
+.bpmn-event-def-message.path-predicted-on-time > rect,
+.bpmn-event-def-message.path-predicted-on-time > path,
+.bpmn-event-def-timer.path-predicted-on-time > path,
+.bpmn-type-event.path-predicted-on-time > ellipse {
+    stroke: var(--color-path-predicted-on-time);
+    fill: var(--color-default-fill);
+}
+
+/* labels (the selector applies to all div, not the only one that contains text, but this is ok.
+ Use important to override the color set inline in the style attribute of the label div */
+.bpmn-label.path-predicted-on-time > g div {
+    color: var(--color-path-predicted-on-time) !important;
+    font-weight: bold;
 }

--- a/demo/predictions/index.html
+++ b/demo/predictions/index.html
@@ -30,7 +30,7 @@ limitations under the License.
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.0/dist/bpmn-visualization.min.js"></script>
     <script defer src="./js/bpmn-diagram-bpmn-spec-pizza.js"></script>
     <script defer src="../static/js/use-case.js"></script>
-    <script defer src="js/prediction-use-case.js"></script>
+    <script defer src="./js/prediction-use-case.js"></script>
     <script defer src="./js/index.js"></script>
 </head>
 <body>

--- a/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
+++ b/demo/predictions/js/bpmn-diagram-bpmn-spec-pizza.js
@@ -206,7 +206,7 @@ function pizzaDiagram() {
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-202" bpmnElement="_6-202">
         <dc:Bounds x="817" y="178" width="32" height="32" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="798" y="156" width="71" height="14" />
+          <dc:Bounds x="793" y="156" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Trisotech.Visio__6__6-219" bpmnElement="_6-219">

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -19,49 +19,105 @@ const alreadyExecutedElementsPredictedLate = [
 
 const vendorBakeThePizzaId = '_6-463';
 const vendorWhereIsMyPizzaId = '_6-674';
-const vendorDeliverThePizzaId = '_6-514';
 const customerEvtBasedGwId = '_6-180';
 
 class PredicatedLateUseCase extends UseCase {
     _alreadyExecutedElements;
+    _predictionData = {
+        elementWithPrediction: {
+            bpmnId: vendorBakeThePizzaId,
+            cssClasses: 'state-predicted-late',
+        },
+        predictedPath: {
+            ids: [
+                // customer elements
+                customerEvtBasedGwId,
+                '_6-424', // sequence flow between 'event-based gateway' (running element) and timer event
+                '_6-219', // timer event
+                '_6-426', // sequence flow between 'timer event' and 'Ask for the pizza'
+                '_6-236', // 'Ask for the pizza'
+                // message flow
+                '_6-642',
+                // vendor elements
+                vendorWhereIsMyPizzaId,
+                '_6-748', // sequence flow between 'where is my pizza' and 'Calm customer'
+                '_6-695', // 'Calm customer'
+            ],
+            cssClasses: 'path-predicted-late',
+        },
+    };
 
     constructor(type) {
-        super(type, () => pizzaDiagram(), true);
+        super(type, () => pizzaDiagram(), true, {fit: {type: 'Center', margin: 20}});
         this._alreadyExecutedElements = alreadyExecutedElementsPredictedLate;
     }
 
-    display(dataType) {
-        super.display(dataType);
+    _postLoadDiagram() {
         this._reduceVisibilityOfAlreadyExecutedElements();
-        this._highlightPredictionOnRunningElements();
+        this._highlightRunningElementsWithPrediction();
+        this._toggleHighlightRunningElementsWithoutPrediction();
+        this._registerInteractions();
     }
 
     _reduceVisibilityOfAlreadyExecutedElements() {
         this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(this._alreadyExecutedElements, 'state-already-executed');
     }
 
-    _highlightPredictionOnRunningElements() {
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(vendorBakeThePizzaId, 'state-predicted-late');
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses([vendorWhereIsMyPizzaId, customerEvtBasedGwId], 'state-running');
+    _registerInteractions() {
+        // on hover, highlight the predicted path
+        const bpmnElements = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(this._predictionData.elementWithPrediction.bpmnId);
+        const elementTogglingPath = bpmnElements[0]; // exist and only one
+
+        const highlightPredictedPath = () => {
+            this._toggleHighlightRunningElementsWithoutPrediction();
+            this._bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(this._predictionData.predictedPath.ids, this._predictionData.predictedPath.cssClasses);
+        }
+
+        elementTogglingPath.htmlElement.addEventListener('mouseenter', highlightPredictedPath);
+        elementTogglingPath.htmlElement.addEventListener('mouseleave', highlightPredictedPath);
     }
 
+    _toggleHighlightRunningElementsWithoutPrediction() {
+        this._bpmnVisualization.bpmnElementsRegistry.toggleCssClasses([vendorWhereIsMyPizzaId, customerEvtBasedGwId], 'state-running');
+    }
+
+    _highlightRunningElementsWithPrediction() {
+        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(this._predictionData.elementWithPrediction.bpmnId, this._predictionData.elementWithPrediction.cssClasses);
+    }
 }
 
 
 class PredictedOnTimeUseCase extends PredicatedLateUseCase {
+    _predictionData = {
+        elementWithPrediction: {
+            bpmnId: '_6-514', // vendor 'Deliver the pizza'
+            cssClasses: 'state-predicted-on-time',
+        },
+        predictedPath: {
+            ids: [
+                // customer elements
+                customerEvtBasedGwId,
+                '_6-422', // sequence flow between 'event-based gateway' (running element) and msg event
+                '_6-202', // msg event 'Pizza received'
+                '_6-428', // sequence flow between 'msg event' and 'Pay the pizza'
+                '_6-304', // 'Pay the pizza'
+                // message flow
+                '_6-640', // from vendor 'Deliver the pizza' to customer 'msg event'
+                // vendor elements
+                '_6-634', // sequence flow between 'Deliver the pizza' and 'Receive payment'
+                '_6-565', // 'Receive payment'
+            ],
+            cssClasses: 'path-predicted-on-time'
+        }
+    };
 
     constructor(type) {
         super(type);
         this._alreadyExecutedElements = [...alreadyExecutedElementsPredictedLate, ...[
             // vendor
-            vendorBakeThePizzaId, //'Bake the pizza'
+            vendorBakeThePizzaId,
             '_6-632', // sequence flow between 'Bake the pizza' and 'Deliver the pizza'
         ]];
-    }
-
-    _highlightPredictionOnRunningElements() {
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(vendorDeliverThePizzaId, 'state-predicted-on-time');
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses([vendorWhereIsMyPizzaId, customerEvtBasedGwId], 'state-running');
     }
 
 }

--- a/demo/static/js/use-case.js
+++ b/demo/static/js/use-case.js
@@ -1,14 +1,20 @@
+const defaultLoadOptions = {
+    fit: {type: 'Center', margin: 30}
+}
+
 class UseCase {
     #type;
     #getDiagram;
     #navigationEnabled;
+    #loadOptions;
     _bpmnVisualization;
     #alreadyLoad = false;
 
-    constructor(type, getDiagram, navigationEnabled) {
+    constructor(type, getDiagram, navigationEnabled, loadOptions) {
         this.#type = type;
         this.#getDiagram = getDiagram;
         this.#navigationEnabled = navigationEnabled;
+        this.#loadOptions = {...defaultLoadOptions, ...loadOptions};
     }
 
     display(dataType) {
@@ -17,7 +23,8 @@ class UseCase {
         if (!this.#alreadyLoad) {
             this._bpmnVisualization = this._initBpmnVisualization({container: `${this.#type}-bpmn-container`, navigation: {enabled: this.#navigationEnabled}});
             this._preLoadDiagram();
-            this._bpmnVisualization.load(this.#getDiagram(), {fit: {type: 'Center', margin: 30}});
+            this._bpmnVisualization.load(this.#getDiagram(), this.#loadOptions);
+            this._postLoadDiagram();
             this.#alreadyLoad = true;
         }
     }
@@ -33,6 +40,12 @@ class UseCase {
      * Generic implementation
      */
     _preLoadDiagram() {
+    }
+
+    /**
+     * Generic implementation
+     */
+    _postLoadDiagram() {
     }
 
     /**


### PR DESCRIPTION
Highlight predicted path on hover on predicted late or on-time task.
The style of running elements is toggled when displaying the predicted path to avoid displaying too much information.

### Other changes
#### Display
  - reduce fit margin to enlarge the diagram
  - diagram: increase 'pizza received' label width for no-wrap on highlight
#### CSS
  - simplify definition of the pulse-animation
  - simplify styles by using the generic BPMN CSS classes introduced in v0.21.0
#### Refactor use-case
  - allow passing load options to parent UseCase
  - allow registering style/interactions after diagram load

covers #260

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/261-hightlight_predicted_paths/demo/predictions/index.html


