### PR TITLE
[FEAT] Bump version of other BPMN vendor libs

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -121,7 +121,7 @@ limitations under the License.
 
 <script src="../../static/js/link-to-sources.js"></script>
 <!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.7.1/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-9lFOUedWSYPHv99e53vfrYJBtsbORXflcvMde1c237E=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.9.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-6sVdF06e3b7gVOOVyEZYtZIjq0mzMxjBSbjiOFDXdFo=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.2/dist/bpmn-visualization.min.js"></script>
 

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -123,7 +123,7 @@ limitations under the License.
 <script src="../../static/js/link-to-sources.js"></script>
 <script src="../../static/js/dom-helper.js"></script>
 <!-- load bpmn kie-editors-standalone -->
-<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.13.0/dist/bpmn/index.js" integrity="sha256-gg52khcKzv/5xzHFM80xnaWSxjtOmBm6NO1c4763Xtk=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.15.0/dist/bpmn/index.js" integrity="sha256-GZ/MRPkL+ieTHtJU5kuZyQ3yrGe6p8wCzZp7Bqmfvqo=" crossorigin="anonymous"></script>
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.2/dist/bpmn-visualization.min.js"></script>
 


### PR DESCRIPTION
bpmn-js from 8.7.1 to 8.9.0
kie-editors-standalone from 0.13.0 to 0.15.0

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bump_bpmn-vendors_libs/examples/index.html
