### PR TITLE
[REFACTOR] Remove duplications in comparison with other BPMN vendors

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -125,6 +125,7 @@ limitations under the License.
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.2/dist/bpmn-visualization.min.js"></script>
 
+<script src="shared.js"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/misc/compare-with-bpmn-js/index.js
+++ b/examples/misc/compare-with-bpmn-js/index.js
@@ -1,186 +1,38 @@
-const bpmnVisualizationContainerId = 'container-bpmn-visualization';
-const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: bpmnVisualizationContainerId, navigation: { enabled: true } });
+// the rest of the code is in shared.js (shared with the kie-editors-standalone comparison example)
 
-const bpmnJsContainerId = 'container-bpmn-js';
-const bpmnJsViewer = new BpmnJS({ container: `#${bpmnJsContainerId}` });
+class BpmnJSLibraryComparator extends LibraryComparator {
+  #bpmnJsViewer;
 
-let loadedXml;
-let fitView = false;
-let isBpmnVisualizationAlreadyLoaded = false;
-let isBpmnJsAlreadyLoaded = false;
-
-// Configure custom html elements
-document.getElementById('btn-open-file').addEventListener('change', handleFileSelect, false);
-const bpmnLibraryRadioButtons = document.getElementsByName('bpmnLibrary');
-configureBpmnLibraryRadioButtons();
-configureFitViewButton();
-
-
-function loadWithBpmnVisualization(xml) {
-  if (isBpmnVisualizationAlreadyLoaded) {
-    logBpmnVisu('Diagram already loaded, skipping new load');
-    return;
+  constructor(bpmnVisualizationContainerId, otherLibContainerId, state) {
+    super(bpmnVisualizationContainerId, state);
+    this._otherLibIdentifier = 'bpmn-js';
+    this.#bpmnJsViewer = new BpmnJS({ container: `#${otherLibContainerId}` });
   }
-  logBpmnVisu('Start loading diagram');
-  bpmnVisualization.load(xml, { fit: computeBpmnVisualizationFitOptions() });
-  logBpmnVisu('Diagram loaded');
-  isBpmnVisualizationAlreadyLoaded = true;
-}
 
-async function loadWithBpmnJs(xml) {
-  if (isBpmnJsAlreadyLoaded) {
-    logBpmnJs('Diagram already loaded, skipping new load');
-    return;
+  async _loadWithOtherLib(xml) {
+    return this.#bpmnJsViewer.importXML(xml);
   }
-  logBpmnJs('Starting import XML')
-  await bpmnJsViewer.importXML(xml);
-  logBpmnJs('Import XML done')
-  setZoomLevelBpmnJs();
-  isBpmnJsAlreadyLoaded = true;
-}
 
-function setZoomLevelBpmnJs() {
-  const canvas = bpmnJsViewer.get('canvas');
-  if (fitView) {
-    // 'auto' to zoom into mid
-    canvas.zoom('fit-viewport', 'auto');
-  } else {
-    // pass null to ensure the position of the diagram is taken from the BPMN xml
-    canvas.zoom(1, null);
-  }
-  logBpmnJs(`Zoom level set, fitView ${fitView}`);
-}
-
-function setZoomLevelBpmnVisualization() {
-  bpmnVisualization.fit(computeBpmnVisualizationFitOptions());
-  logBpmnVisu(`Zoom level set, fitView ${fitView}`);
-}
-
-function computeBpmnVisualizationFitOptions() {
-  const fitType = fitView ? bpmnvisu.FitType.Center: bpmnvisu.FitType.None;
-  return { type: fitType, margin: 10 };
-}
-
-function handleFileSelect(evt) {
-  evt.stopPropagation();
-  evt.preventDefault();
-
-  const file = evt.target.files[0];
-  logMain(`New file selected for load: ${file.name}`);
-  const reader = new FileReader();
-  reader.onload = () => {
-    isBpmnVisualizationAlreadyLoaded = false;
-    isBpmnJsAlreadyLoaded = false;
-    loadBpmn(reader.result);
-
-    document.getElementById('loading-info').classList.remove('hidden');
-    document.querySelector('#loading-info > span').innerHTML = `<code>${file.name}</code>`;
-  };
-  reader.readAsText(file);
-}
-
-function loadBpmn(xml) {
-  const useBpmnVisualization = isUseBpmnVisualization();
-  displayBpmnContainer(useBpmnVisualization);
-
-  // effective load
-  try {
-    logMain(`Ready to load BPMN with fitView: ${fitView}`);
-    if (useBpmnVisualization) {
-      loadWithBpmnVisualization(xml);
+  _setZoomLevelOtherLib() {
+    const canvas = this.#bpmnJsViewer.get('canvas');
+    if (this._state.fitView) {
+      // 'auto' to zoom into mid
+      canvas.zoom('fit-viewport', 'auto');
     } else {
-      loadWithBpmnJs(xml);
+      // pass null to ensure the position of the diagram is taken from the BPMN xml
+      canvas.zoom(1, null);
     }
-    loadedXml = xml;
-  } catch (err) {
-    console.error('[main] Unable to load BPMN diagram', err);
+    this._logOtherLib(`Zoom level set, fitView ${this._state.fitView}`);
   }
 }
 
-function reloadAfterBpmnLibrarySwitch() {
-  logMain('BPMN Library switch detected');
-  if (!loadedXml) {
-    return;
-  }
-  logMain('Reloading the BPMN diagram');
-  loadBpmn(loadedXml);
+
+const state = {
+  fitView: false,
+  isUseBpmnVisualization: true,
 }
 
+const libraryComparator = new BpmnJSLibraryComparator('container-bpmn-visualization', 'container-bpmn-js', state);
 
-function configureFitViewButton() {
-  const fitViewElt = document.getElementById('fitView');
-
-  fitView = fitViewElt.checked;
-  logMain(`Initial fitView: ${fitView}`);
-
-  fitViewElt.addEventListener('change', function(event) {
-    fitView = event.target.checked;
-    changeZoomLevel();
-  });
-}
-
-function changeZoomLevel() {
-  logMain('Zoom level switch detected');
-  if (!loadedXml) {
-    return;
-  }
-  logMain(`Changing zoom level with fitView: ${fitView}`);
-  if (isUseBpmnVisualization()) {
-    setZoomLevelBpmnVisualization();
-  } else {
-    setZoomLevelBpmnJs();
-  }
-}
-
-function configureBpmnLibraryRadioButtons() {
-  for (let i = 0, length = bpmnLibraryRadioButtons.length; i < length; i++) {
-    bpmnLibraryRadioButtons[i].addEventListener('change', reloadAfterBpmnLibrarySwitch);
-  }
-}
-
-function isUseBpmnVisualization() {
-  return getSelectedBpmnLibrary() === 'bpmn-visualization';
-}
-
-function getSelectedBpmnLibrary() {
-  let bpmnLibrary;
-  for (let i = 0, length = bpmnLibraryRadioButtons.length; i < length; i++) {
-    if (bpmnLibraryRadioButtons[i].checked) {
-      bpmnLibrary = bpmnLibraryRadioButtons[i].value;
-      break;
-    }
-  }
-  bpmnLibrary = bpmnLibrary ?? 'bpmn-visualization';
-  logMain(`Selected lib: ${bpmnLibrary}`)
-  return bpmnLibrary;
-}
-
-
-function displayBpmnContainer(useBpmnVisualization) {
-  const bpmnVisualizationContainerElt = document.getElementById(bpmnVisualizationContainerId);
-  const bpmnJsContainerElt = document.getElementById(bpmnJsContainerId);
-
-  if (useBpmnVisualization) {
-    bpmnVisualizationContainerElt.classList.remove('hidden');
-    bpmnJsContainerElt.classList.add('hidden');
-  } else {
-    bpmnJsContainerElt.classList.remove('hidden');
-    bpmnVisualizationContainerElt.classList.add('hidden');
-  }
-}
-
-function log(header, msg) {
-  console.info(`[${header}] ${msg}`);
-}
-
-function logBpmnJs(msg) {
-  log('bpmn-js', msg)
-}
-
-function logBpmnVisu(msg) {
-  log('bpmn-visualization', msg)
-}
-
-function logMain(msg) {
-  log('main', msg)
-}
+const uiController = new UIController(state, libraryComparator, 'container-bpmn-visualization', 'container-bpmn-js');
+uiController.configure();

--- a/examples/misc/compare-with-bpmn-js/shared.js
+++ b/examples/misc/compare-with-bpmn-js/shared.js
@@ -1,0 +1,217 @@
+class LibraryComparator {
+    #loadedBpmnXmlContent = null;
+    #isBpmnVisualizationAlreadyLoaded = false;
+    _isOtherLibAlreadyLoaded = false;
+    _otherLibIdentifier;
+    _state;
+
+    #bpmnVisualization;
+
+    constructor(bpmnVisualizationContainerId, state) {
+        this.#bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: bpmnVisualizationContainerId, navigation: { enabled: true } });
+        this._state = state;
+    }
+
+    loadNewBpmn(xml) {
+        this._resetLoadStatus();
+        return this._performLoadBpmn(xml);
+    }
+
+    _resetLoadStatus() {
+        this.#isBpmnVisualizationAlreadyLoaded = false;
+        this._isOtherLibAlreadyLoaded = false;
+    }
+
+    async _performLoadBpmn(xml) {
+        logMain(`Ready to load BPMN with fitView: ${this._state.fitView}`);
+        if (this._state.isUseBpmnVisualization) {
+            if (this.#isBpmnVisualizationAlreadyLoaded) {
+                this._logBpmnVisualization('Diagram already loaded, skipping new load');
+                return;
+            }
+            await new Promise((resolve, reject) => {
+                try {
+                    this._logBpmnVisualization('Start loading diagram')
+                    this.#bpmnVisualization.load(xml, {fit: this._computeBpmnVisualizationFitOptions()});
+                    this._logBpmnVisualization('Diagram loaded');
+                    this.#isBpmnVisualizationAlreadyLoaded = true;
+                    this.#loadedBpmnXmlContent = xml;
+                    return resolve();
+                } catch (err) {
+                    return reject({libId: 'bpmn-visualization', cause: err});
+                }
+                });
+        } else {
+            if (this._isOtherLibAlreadyLoaded) {
+                this._logOtherLib('Diagram already loaded, skipping new load');
+                return;
+            }
+            await new Promise((resolve, reject) => {
+                this._logOtherLib('Start loading diagram');
+                this._loadWithOtherLib(xml)
+                    .then(() => {
+                        this._logOtherLib('Diagram loaded');
+                        this._setZoomLevelOtherLib();
+                        this._isOtherLibAlreadyLoaded = true;
+                        this.#loadedBpmnXmlContent = xml;
+                        return resolve();
+                    })
+                    .catch(err => {
+                        return reject({libId: this._otherLibIdentifier, cause: err});
+                    })
+                ;
+            });
+        }
+    }
+
+    loadExistingBpmn() {
+        logMain('Loading an existing BPMN diagram');
+        if (!this.#loadedBpmnXmlContent) {
+            logMain('No loaded BPMN content, nothing to do');
+            return;
+        }
+        this._performLoadBpmn(this.#loadedBpmnXmlContent);
+    }
+
+    _computeBpmnVisualizationFitOptions() {
+        const fitType = this._state.fitView ? bpmnvisu.FitType.Center: bpmnvisu.FitType.None;
+        return { type: fitType, margin: 10 };
+    }
+
+    async _loadWithOtherLib(xml) {
+        // implement in subclass
+    }
+
+    changeZoomLevel() {
+        logMain('Zoom level switch detected');
+        if (!this.#loadedBpmnXmlContent) {
+            logMain('No loaded BPMN content, nothing to do');
+            return;
+        }
+        logMain(`Changing zoom level with fitView: ${this._state.fitView}`);
+        if (this._state.isUseBpmnVisualization) {
+            this._setZoomLevelBpmnVisualization();
+        } else {
+            this._setZoomLevelOtherLib();
+        }
+    }
+
+    _setZoomLevelBpmnVisualization() {
+        this.#bpmnVisualization.fit(this._computeBpmnVisualizationFitOptions());
+        this._logBpmnVisualization(`Zoom level set, fitView ${this._state.fitView}`);
+    }
+
+    _setZoomLevelOtherLib() {
+        // implement in subclass
+    }
+
+    _logBpmnVisualization(msg) {
+        log('bpmn-visualization', msg)
+    }
+
+    _logOtherLib(msg) {
+        log(this._otherLibIdentifier, msg);
+    }
+}
+
+class UIController {
+    _state;
+    #libraryComparator;
+    #bpmnLibraryRadioButtons;
+    _bpmnVisualizationContainerId;
+    _otherLibContainerId;
+
+    constructor(state, libraryComparator, bpmnVisualizationContainerId, otherLibContainerId) {
+        this._state = state;
+        this.#libraryComparator = libraryComparator;
+        this._bpmnVisualizationContainerId = bpmnVisualizationContainerId;
+        this._otherLibContainerId = otherLibContainerId;
+    }
+
+    configure() {
+        document.getElementById('btn-open-file').addEventListener('change', this._handleFileSelect.bind(this), false);
+        this.#bpmnLibraryRadioButtons = document.getElementsByName('bpmnLibrary');
+        this._configureBpmnLibraryRadioButtons();
+        this._configureFitViewButton();
+    }
+
+    _configureFitViewButton() {
+        const fitViewElt = document.getElementById('fitView');
+
+        this._state.fitView = fitViewElt.checked;
+        logMain(`Initial fitView: ${this._state.fitView}`);
+
+        fitViewElt.addEventListener('change', event => {
+            this._state.fitView = event.target.checked;
+            this.#libraryComparator.changeZoomLevel();
+        });
+    }
+
+    _configureBpmnLibraryRadioButtons() {
+        this._state.isUseBpmnVisualization = this._isUseBpmnVisualization();
+        logMain(`Initial used library is BpmnVisualization: ${this._state.isUseBpmnVisualization}`);
+
+        for (let i = 0, length = this.#bpmnLibraryRadioButtons.length; i < length; i++) {
+            this.#bpmnLibraryRadioButtons[i].addEventListener('change', () => {
+                this._state.isUseBpmnVisualization = this._isUseBpmnVisualization();
+                this._updateUIBasedOnState();
+                this.#libraryComparator.loadExistingBpmn();
+            });
+        }
+    }
+
+    _isUseBpmnVisualization() {
+        let bpmnLibrary;
+        for (let i = 0, length = this.#bpmnLibraryRadioButtons.length; i < length; i++) {
+            if (this.#bpmnLibraryRadioButtons[i].checked) {
+                bpmnLibrary = this.#bpmnLibraryRadioButtons[i].value;
+                break;
+            }
+        }
+        bpmnLibrary = bpmnLibrary ?? 'bpmn-visualization';
+        logMain(`Selected lib: ${bpmnLibrary}`)
+        return bpmnLibrary === 'bpmn-visualization';
+    }
+
+    _handleFileSelect(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+
+        const file = evt.target.files[0];
+        logMain(`New file selected for load: ${file.name}`);
+        const reader = new FileReader();
+        reader.onload = () => {
+            this.#libraryComparator.loadNewBpmn(reader.result)
+                .then(() => {
+                    document.getElementById('loading-info').classList.remove('hidden');
+                    document.querySelector('#loading-info > span').innerHTML = `<code>${file.name}</code>`;
+                })
+                .catch(err => {
+                    console.error(`[${err.libId}] Unable to load the BPMN diagram.`, err.cause);
+                })
+            ;
+        };
+        reader.readAsText(file);
+    }
+
+    _updateUIBasedOnState() {
+        const bpmnVisualizationContainerElt = document.getElementById(this._bpmnVisualizationContainerId);
+        const bpmnOtherLibContainerElt = document.getElementById(this._otherLibContainerId);
+
+        if (this._state.isUseBpmnVisualization) {
+            bpmnVisualizationContainerElt.classList.remove('hidden');
+            bpmnOtherLibContainerElt.classList.add('hidden');
+        } else {
+            bpmnOtherLibContainerElt.classList.remove('hidden');
+            bpmnVisualizationContainerElt.classList.add('hidden');
+        }
+    }
+}
+
+function log(header, msg) {
+    console.info(`[${header}] ${msg}`);
+}
+
+function logMain(msg) {
+    log('main', msg)
+}

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -127,6 +127,7 @@ limitations under the License.
 <!-- load bpmn-visualization -->
 <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.2/dist/bpmn-visualization.min.js"></script>
 
+<script src="../compare-with-bpmn-js/shared.js"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/misc/compare-with-kie-editors-standalone/index.js
+++ b/examples/misc/compare-with-kie-editors-standalone/index.js
@@ -1,182 +1,62 @@
-const bpmnVisualizationContainerId = 'container-bpmn-visualization';
-const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: bpmnVisualizationContainerId, navigation: { enabled: true } });
+// the rest of the code is in '../compare-with-bpmn-js/shared.js'
 
-const kieBpmnEditorContainerId = 'container-kie-editors-standalone';
-const kieBpmnEditor = BpmnEditor.open({
-  container: document.getElementById(kieBpmnEditorContainerId),
-  readOnly: true, // available as of 0.9.0 (https://blog.kie.org/2021/04/design-tools-highlights-on-kogito-and-business-central-april-2021.html)
-  onError: () => { logKieBpmn('Error occurs (probably while setting content)') }, // seems to be called only when the first error occurs, never again
-});
-kieBpmnEditor.subscribeToContentChanges((isDirty) => { logKieBpmn(`Content change detected, isDirty?${isDirty}`)})
+// TODO pass the filename to kie editor (must be available in LibraryComparator)
 
-let loadedXml;
-let fitView = true;
-let isBpmnVisualizationAlreadyLoaded = false;
-let isKieBpmnAlreadyLoaded = false;
+class KieBpmnEditorLibraryComparator extends LibraryComparator {
+  #kieBpmnEditor;
 
-// Configure custom html elements
-document.getElementById('btn-open-file').addEventListener('change', handleFileSelect, false);
-const bpmnLibraryRadioButtons = document.getElementsByName('bpmnLibrary');
-configureBpmnLibraryRadioButtons();
-configureFitViewButton();
-
-
-function loadWithBpmnVisualization(xml) {
-  if (isBpmnVisualizationAlreadyLoaded) {
-    logBpmnVisu('Diagram already loaded, skipping new load');
-    return;
+  constructor(bpmnVisualizationContainerId, otherLibContainerId, state) {
+    super(bpmnVisualizationContainerId, state);
+    this._otherLibIdentifier = 'kie-editors-standalone';
+    this.#kieBpmnEditor = BpmnEditor.open({
+      container: document.getElementById(otherLibContainerId),
+      readOnly: true, // available as of 0.9.0 (https://blog.kie.org/2021/04/design-tools-highlights-on-kogito-and-business-central-april-2021.html)
+      onError: () => { console.error(`[${this._otherLibIdentifier}] Error occurs (probably while setting content)`) }, // seems to be called only when the first error occurs, never again
+    });
+    this.#kieBpmnEditor.subscribeToContentChanges((isDirty) => { this._logOtherLib(`Content change detected, isDirty?${isDirty}`)})
   }
-  logBpmnVisu('Start loading diagram');
-  bpmnVisualization.load(xml, { fit: computeBpmnVisualizationFitOptions() });
-  logBpmnVisu('Diagram loaded');
-  isBpmnVisualizationAlreadyLoaded = true;
-}
 
-async function loadWithKieBpmn(xml) {
-  if (isKieBpmnAlreadyLoaded) {
-    logKieBpmn('Diagram already loaded, skipping new load');
-    return;
+  async _loadWithOtherLib(xml) {
+    return this.#kieBpmnEditor.setContent("from-local-content", xml);
   }
-  logKieBpmn('Starting setting content')
-  kieBpmnEditor.setContent("from-local-content", xml)
-      .then(() => {
-        logKieBpmn('Content set successfully!');
-        setZoomLevelKieBpmn();
-        isKieBpmnAlreadyLoaded = true;
-      })
-      .catch(() => logKieBpmn('Error while setting content'));
-}
 
-function setZoomLevelKieBpmn() {
-  // TODO see if we have something for kie-editors-standalone
-  logKieBpmn('no zoom settings for now');
-}
-
-function setZoomLevelBpmnVisualization() {
-  bpmnVisualization.fit(computeBpmnVisualizationFitOptions());
-  logBpmnVisu(`Zoom level set, fitView ${fitView}`);
-}
-
-function computeBpmnVisualizationFitOptions() {
-  const fitType = fitView ? bpmnvisu.FitType.Center: bpmnvisu.FitType.None;
-  return { type: fitType, margin: 10 };
-}
-
-function handleFileSelect(evt) {
-  evt.stopPropagation();
-  evt.preventDefault();
-
-  const file = evt.target.files[0];
-  logMain(`New file selected for load: ${file.name}`);
-  const reader = new FileReader();
-  reader.onload = () => {
-    isBpmnVisualizationAlreadyLoaded = false;
-    isKieBpmnAlreadyLoaded = false;
-    loadBpmn(reader.result);
-
-    document.getElementById('loading-info').classList.remove('hidden');
-    document.querySelector('#loading-info > span').innerHTML = `<code>${file.name}</code>`;
-  };
-  reader.readAsText(file);
-}
-
-function loadBpmn(xml) {
-  const useBpmnVisualization = isUseBpmnVisualization();
-  displayBpmnContainer(useBpmnVisualization);
-
-  // effective load
-  try {
-    logMain(`Ready to load BPMN with fitView: ${fitView}`);
-    if (useBpmnVisualization) {
-      loadWithBpmnVisualization(xml);
-    } else {
-      loadWithKieBpmn(xml);
-    }
-    loadedXml = xml;
-  } catch (err) {
-    console.error('[main] Unable to load BPMN diagram', err);
+  _setZoomLevelOtherLib() {
+    this._logOtherLib('No zoom settings for now, so do nothing');
   }
 }
 
-function reloadAfterBpmnLibrarySwitch() {
-  logMain('BPMN Library switch detected');
-  if (!loadedXml) {
-    return;
+class CustomUIController extends UIController {
+  _configureFitViewButton() {
+    const buttonElt = document.getElementById('btn-fit-view');
+    const buttonTextFit = buttonElt.innerText;
+    const buttonTitleFit = buttonElt.title;
+    const buttonTextNoFit = 'No Fit View '; // trailing space must be kept
+
+    setButtonState('btn-fit-view', !this._state.isUseBpmnVisualization);
+
+    buttonElt.addEventListener('click', () => {
+      this._state.fitView = !this._state.fitView;
+      // TODO use the '_libraryComparator' property instead
+      libraryComparator.changeZoomLevel();
+
+      // The text is in a span
+      buttonElt.firstElementChild.innerText = this._state.fitView ? buttonTextNoFit : buttonTextFit;
+      buttonElt.title = this._state.fitView ? 'Restore the default zoom level' : buttonTitleFit;
+    });
   }
-  logMain('Reloading the BPMN diagram');
-  loadBpmn(loadedXml);
-}
 
-
-function configureFitViewButton() {
-  document.getElementById('btn-fit-view').addEventListener('click', function(event) {
-    changeZoomLevel();
-  });
-}
-
-function changeZoomLevel() {
-  logMain('Zoom level switch detected');
-  if (!loadedXml) {
-    return;
-  }
-  logMain(`Changing zoom level with fitView: ${fitView}`);
-  if (isUseBpmnVisualization()) {
-    setZoomLevelBpmnVisualization();
-  } else {
-    setZoomLevelKieBpmn();
+  _updateUIBasedOnState() {
+    super._updateUIBasedOnState();
+    setButtonState('btn-fit-view', !this._state.isUseBpmnVisualization);
   }
 }
 
-function configureBpmnLibraryRadioButtons() {
-  for (let i = 0, length = bpmnLibraryRadioButtons.length; i < length; i++) {
-    bpmnLibraryRadioButtons[i].addEventListener('change', reloadAfterBpmnLibrarySwitch);
-  }
+const state = {
+  fitView: false,
+  isUseBpmnVisualization: true,
 }
 
-function isUseBpmnVisualization() {
-  return getSelectedBpmnLibrary() === 'bpmn-visualization';
-}
+const libraryComparator = new KieBpmnEditorLibraryComparator('container-bpmn-visualization', 'container-kie-editors-standalone', state);
 
-function getSelectedBpmnLibrary() {
-  let bpmnLibrary;
-  for (let i = 0, length = bpmnLibraryRadioButtons.length; i < length; i++) {
-    if (bpmnLibraryRadioButtons[i].checked) {
-      bpmnLibrary = bpmnLibraryRadioButtons[i].value;
-      break;
-    }
-  }
-  bpmnLibrary = bpmnLibrary ?? 'bpmn-visualization';
-  logMain(`Selected lib: ${bpmnLibrary}`)
-  return bpmnLibrary;
-}
-
-
-function displayBpmnContainer(useBpmnVisualization) {
-  const bpmnVisualizationContainerElt = document.getElementById(bpmnVisualizationContainerId);
-  const kieBpmnContainerElt = document.getElementById(kieBpmnEditorContainerId);
-
-  if (useBpmnVisualization) {
-    bpmnVisualizationContainerElt.classList.remove('hidden');
-    kieBpmnContainerElt.classList.add('hidden');
-  } else {
-    kieBpmnContainerElt.classList.remove('hidden');
-    bpmnVisualizationContainerElt.classList.add('hidden');
-  }
-  setButtonState('btn-fit-view', !useBpmnVisualization);
-}
-
-function log(header, msg) {
-  console.info(`[${header}] ${msg}`);
-}
-
-function logKieBpmn(msg) {
-  log('kie-editors-standalone', msg)
-}
-
-function logBpmnVisu(msg) {
-  log('bpmn-visualization', msg)
-}
-
-function logMain(msg) {
-  log('main', msg)
-}
+const uiController = new CustomUIController(state, libraryComparator, 'container-bpmn-visualization', 'container-kie-editors-standalone');
+uiController.configure();


### PR DESCRIPTION
Introduce shared classes for library and UI management + a 'state' shared object.
Examples extend them which reduces duplications a lot.

The shared classes allow a clearer separation between the libs management and actions on the UI.
Errors are better handled: for instance, the 'Last loaded file' info is no longer updated on load failure.

kie-editors-standalone example: manage the 'Fit View' button title and text based on the 'fitView' state for a better feedback for the user.

closes #127 

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/127-remove_duplications_in_bpmn-vendors_comparison_examples/examples/index.html
