### PR TITLE
[FEAT] Display the file name in the KIE editor panels

### DIFF
--- a/examples/misc/compare-with-kie-editors-standalone/index.js
+++ b/examples/misc/compare-with-kie-editors-standalone/index.js
@@ -1,7 +1,5 @@
 // the rest of the code is in '../compare-with-bpmn-js/shared.js'
 
-// TODO pass the filename to kie editor (must be available in LibraryComparator)
-
 class KieBpmnEditorLibraryComparator extends LibraryComparator {
   #kieBpmnEditor;
 
@@ -16,8 +14,8 @@ class KieBpmnEditorLibraryComparator extends LibraryComparator {
     this.#kieBpmnEditor.subscribeToContentChanges((isDirty) => { this._logOtherLib(`Content change detected, isDirty?${isDirty}`)})
   }
 
-  async _loadWithOtherLib(xml) {
-    return this.#kieBpmnEditor.setContent("from-local-content", xml);
+  async _loadWithOtherLib(xml, resourceName) {
+    return this.#kieBpmnEditor.setContent(resourceName, xml);
   }
 
   _setZoomLevelOtherLib() {


### PR DESCRIPTION
It is now visible in the Diagram Explorer and Properties panels.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/display_file_name_in_kie_editor_panels/examples/index.html


### Screenshots

![kie_diagram_explorer](https://user-images.githubusercontent.com/27200110/149886202-daacfb9d-17db-4fce-ad13-e4e114cd4849.png)
![kie-properties_panel](https://user-images.githubusercontent.com/27200110/149886204-7dc7f9ac-e2b1-42aa-af8c-796c1faf5a94.png)

