### PR TITLE
[FEAT] Improve types support in the ViteJS TS project

### DIFF
--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -5,15 +5,15 @@ on:
       - master
     paths:
       - '.github/workflows/check-typescript-projects.yml'
-      - 'examples/projects/typescript-vanilla-with-rollup'
-      - 'examples/projects/typescript-vanilla-with-vitejs'
+      - 'examples/projects/typescript-vanilla-with-rollup/**/*'
+      - 'examples/projects/typescript-vanilla-with-vitejs/**/*'
   pull_request:
     branches:
       - master
     paths:
       - '.github/workflows/check-typescript-projects.yml'
-      - 'examples/projects/typescript-vanilla-with-rollup'
-      - 'examples/projects/typescript-vanilla-with-vitejs'
+      - 'examples/projects/typescript-vanilla-with-rollup/**/*'
+      - 'examples/projects/typescript-vanilla-with-vitejs/**/*'
 
 jobs:
   check:

--- a/examples/projects/typescript-vanilla-with-vitejs/package.json
+++ b/examples/projects/typescript-vanilla-with-vitejs/package.json
@@ -11,6 +11,7 @@
     "bpmn-visualization": "0.21.4"
   },
   "devDependencies": {
+    "@typed-mxgraph/typed-mxgraph": "^1.0.4",
     "typescript": "^4.5.5",
     "vite": "^2.8.1"
   }

--- a/examples/projects/typescript-vanilla-with-vitejs/tsconfig.json
+++ b/examples/projects/typescript-vanilla-with-vitejs/tsconfig.json
@@ -13,7 +13,14 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true, // bpmn-visualization@0.21.4 definitions miss some types
+    "skipLibCheck": false,
+    "typeRoots": [
+      "node_modules/@types",
+      // The bpmn-visualization types reference "typed-mxgraph"
+      // So, install "@typed-mxgraph/typed-mxgraph" as "devDependencies" in addition to the following configuration
+      // Alternative, don't add the devDependencies and this configuration and set "skipLibCheck" to true
+      "node_modules/@typed-mxgraph"
+    ]
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/examples/projects/typescript-vanilla-with-vitejs/tsconfig.json
+++ b/examples/projects/typescript-vanilla-with-vitejs/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": false,
+    // bpmn-visualization@0.21.5 will fix definitions (some types are missing in previous version). Then, we will be able to set it to "false"
+    "skipLibCheck": true,
     "typeRoots": [
       "node_modules/@types",
       // The bpmn-visualization types reference "typed-mxgraph"


### PR DESCRIPTION
Add typed-mxgraph as devDependencies and explain an alternative way without this dependency.

covers https://github.com/process-analytics/bpmn-visualization-js/issues/1808
relates to https://github.com/process-analytics/bpmn-visualization-js/pull/1814: the current PR has been used to test the types provided by the bpmn-visualization PR