### PR TITLE
[DOC] Improve README about usage in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Go to the repository root and use one the following solutions
 ## 🚸 Prerequisites for reuse in projects
 
 Some examples are provided for direct use in the web browser. I you want to integrate their related code in a project, adaptations may be required.
-In particular, TypeScript users should read the paragraph about the [TypeScript support in the bpmn-visualization README](https://github.com/process-analytics/bpmn-visualization-js/#-typescript-support) and check the [examples projects](#projects) in this repository. 
+
+You can check the [examples projects](#projects) in this repository or the [Live IDE examples](#live_ide) to know how to bootstrap `bpmn-visualization` in a project.
+
+TypeScript users should also read the paragraph about the [TypeScript support in the bpmn-visualization README](https://github.com/process-analytics/bpmn-visualization-js/#-typescript-support). 
 
 
 ## 👁️‍🗨️ Demos
@@ -112,6 +115,7 @@ Custom BPMN Theme features will be progressively added to `bpmn-visualization`. 
 
 ### Miscellaneous examples
 
+<a name="live_ide"></a>
 #### Playgrounds in live IDE
 - [CodeSandbox Template](https://codesandbox.io/s/bpmn-visualization-sandbox-hpvq8) - Play with the `bpmn-visualization` API. Use the template to demonstrate missing features or bugs.
 - [Play with the `bpmn-visualization` API in Codepen](https://codepen.io/process-analytics/pen/YzQzROg) - Experiment `bpmn-visualization` integration and API usage live in your browser

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 
 This repository contains examples showing how to use [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
+## 🚸 Prerequisites
+
+Some examples are provided for direct use in the web browser. I you want to integrate their related code in a project, adaptations may be required.
+In particular, TypeScript users should read the paragraph about the [TypeScript support in the bpmn-visualization README](https://github.com/process-analytics/bpmn-visualization-js/#-typescript-support) and check the [examples projects](#projects) in this repository. 
+
 
 ## 🎮 Live Environment
 
@@ -116,6 +121,7 @@ Custom BPMN Theme features will be progressively added to `bpmn-visualization`. 
 - [Compare `bpmn-visualization` with `kie-editors-standalone`](./examples/misc/compare-with-kie-editors-standalone/README.md) - compare the libraries on BPMN elements rendering and API usage
 
 
+<a id="projects"></a>
 ### `bpmn-visualization` usage in projects
 
 - [JavaScript + webpack](examples/projects/javascript-vanilla-with-webpack/README.md) - integration in a vanilla JavaScript webpack project

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Go to the repository root and use one the following solutions
 
 ## 🚸 Prerequisites for reuse in projects
 
-Some examples are provided for direct use in the web browser. I you want to integrate their related code in a project, adaptations may be required.
+Some examples are provided for direct use in the web browser. If you want to integrate their related code in a project, adaptations may be required.
 
 You can check the [examples projects](#projects) in this repository or the [Live IDE examples](#live_ide) to know how to bootstrap `bpmn-visualization` in a project.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 This repository contains examples showing how to use [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
+
 ## 🎮 Live Environment
 
 Give a try to the [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html)

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@
 
 This repository contains examples showing how to use [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
-## 🚸 Prerequisites
-
-Some examples are provided for direct use in the web browser. I you want to integrate their related code in a project, adaptations may be required.
-In particular, TypeScript users should read the paragraph about the [TypeScript support in the bpmn-visualization README](https://github.com/process-analytics/bpmn-visualization-js/#-typescript-support) and check the [examples projects](#projects) in this repository. 
-
-
 ## 🎮 Live Environment
 
 Give a try to the [__⏩ live environment__](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html)
@@ -55,6 +49,12 @@ Go to the repository root and use one the following solutions
 - python3: `python3 -m http.server 8002` and go to http://localhost:8002/examples/ 
 - nodejs/npm: `npx http-server --port 8003  -o ./examples` and your default web browser opens http://localhost:8003/examples/ 
 - .... your own lovely web server
+
+
+## 🚸 Prerequisites for reuse in projects
+
+Some examples are provided for direct use in the web browser. I you want to integrate their related code in a project, adaptations may be required.
+In particular, TypeScript users should read the paragraph about the [TypeScript support in the bpmn-visualization README](https://github.com/process-analytics/bpmn-visualization-js/#-typescript-support) and check the [examples projects](#projects) in this repository. 
 
 
 ## 👁️‍🗨️ Demos

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Custom BPMN Theme features will be progressively added to `bpmn-visualization`. 
 
 ### Miscellaneous examples
 
-<a name="live_ide"></a>
+<a id="live_ide"></a>
 #### Playgrounds in live IDE
 - [CodeSandbox Template](https://codesandbox.io/s/bpmn-visualization-sandbox-hpvq8) - Play with the `bpmn-visualization` API. Use the template to demonstrate missing features or bugs.
 - [Play with the `bpmn-visualization` API in Codepen](https://codepen.io/process-analytics/pen/YzQzROg) - Experiment `bpmn-visualization` integration and API usage live in your browser


### PR DESCRIPTION
Add a dedicated paragraph about how to reuse the examples content in projects with a special note for TypeScript.

Based on feedback from #294