### PR TITLE
[DOC] Remove reference to mxConstants in README files

### DIFF
--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -14,8 +14,10 @@ See the [development documentation](https://github.com/process-analytics/bpmn-vi
 
 ⚠️To avoid having to many content in the README, we simplify it. You can find all the content of the example in [index.js](index.js).
 
-ℹ in the following code examples, the `mxConstants` object comes from mxGraph. If it is not available, you can use the string value instead (for reference, see the [mxConstants API](https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants))
-or define constants like in [style-identifier.js](../../static/js/style-identifiers.js).
+ℹ In the following code examples, the `style` keys and values constants are related to the `mxConstants` object that comes from mxGraph.
+For reference, see the [mxConstants API](https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants). \
+We are using `Directions` and `StyleIdentifiers` here that store the constants string values. They are defined in [style-identifier.js](../../static/js/style-identifiers.js).
+But you can also use the string value directly, for instance `style['fillColor']=...`.
 
 Content:
 - override default font color: update the `StyleDefault` default values
@@ -28,8 +30,8 @@ StyleDefault.DEFAULT_FONT_COLOR = 'Cyan';
 const originalConfigureCommonDefaultStyle = StyleConfigurator.configureCommonDefaultStyle;
 StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[mxConstants.STYLE_FILLCOLOR] = 'LemonChiffon';
-    style[mxConstants.STYLE_STROKECOLOR] = 'Orange';
+    style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
 }
 ```
 
@@ -47,17 +49,17 @@ class BpmnVisualizationCustomColors extends BpmnVisualization {
 
         ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[mxConstants.STYLE_FILLCOLOR] = 'Pink';
+            style[StyleIdentifiers.STYLE_FILLCOLOR] = 'Pink';
         });
 
         ShapeUtil.taskKinds().forEach(kind => {
             const style = styleSheet.styles[kind];
-            style[mxConstants.STYLE_GRADIENT_DIRECTION] = mxConstants.DIRECTION_EAST;
-            style[mxConstants.STYLE_GRADIENTCOLOR] = 'White';
+            style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_EAST;
+            style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = 'White';
         });
 
         const poolStyle = styleSheet.styles[ShapeBpmnElementKind.POOL];
-        poolStyle[mxConstants.STYLE_FILLCOLOR] = 'PaleGreen';
+        poolStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'PaleGreen';
     }
 }
 
@@ -77,11 +79,11 @@ class BpmnVisualizationCustomEventColors extends BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const startEventStyle = styleSheet.styles[ShapeBpmnElementKind.EVENT_START];
-        startEventStyle[mxConstants.STYLE_FILLCOLOR] = '#d6eea5';
+        startEventStyle[StyleIdentifiers.STYLE_FILLCOLOR] = '#d6eea5';
 
         [ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW].forEach(kind => {
             const intermediateEventStyle = styleSheet.styles[kind];
-            intermediateEventStyle[mxConstants.STYLE_STROKECOLOR] = '#7307df';
+            intermediateEventStyle[StyleIdentifiers.STYLE_STROKECOLOR] = '#7307df';
         })
     }
 }
@@ -101,7 +103,7 @@ class BpmnVisualizationCustomColorsUserTask extends BpmnVisualization {
     configureStyle() {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
         const style = styleSheet.styles[ShapeBpmnElementKind.TASK_USER];
-        style[mxConstants.STYLE_FONTCOLOR] = '#2b992a';
+        style[StyleIdentifiers.STYLE_FONTCOLOR] = '#2b992a';
    }
 }
 

--- a/examples/custom-bpmn-theme/custom-fonts/README.md
+++ b/examples/custom-bpmn-theme/custom-fonts/README.md
@@ -14,8 +14,10 @@ See the [development documentation](https://github.com/process-analytics/bpmn-vi
 
 ⚠️To avoid having to many content in the README, we simplify it. You can find all the content of the example in [index.js](index.js).
 
-ℹ in the following code examples, the `mxConstants` object comes from mxGraph. If it is not available, you can use the string value instead (for reference, see the [mxConstants API](https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants))
-or define constants like in [style-identifier.js](../../static/js/style-identifiers.js).
+ℹ In the following code examples, the `style` keys and values constants are related to the `mxConstants` object that comes from mxGraph.
+For reference, see the [mxConstants API](https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants). \
+We are using `FontStyle` and `StyleIdentifiers` here that store the constants string values. They are defined in [style-identifier.js](../../static/js/style-identifiers.js).
+But you can also use the string value directly, for instance `style['fontStyle']=...`.
 
 
 Content:
@@ -30,7 +32,7 @@ Content:
 ```javascript
 StyleConfigurator.configureCommonDefaultStyle = function (style) {
     originalConfigureCommonDefaultStyle(style);
-    style[mxConstants.STYLE_FONTSTYLE] = mxConstants.FONT_ITALIC;
+    style[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
 }
 ```
 
@@ -47,9 +49,9 @@ class BpmnVisualizationCustomFonts extends BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         const userTaskStyle = styleSheet.styles[ShapeBpmnElementKind.TASK_USER];
-        userTaskStyle[mxConstants.STYLE_FONTFAMILY] = 'Courier New,serif';
-        userTaskStyle[mxConstants.STYLE_FONTSIZE] = '14';
-        userTaskStyle[mxConstants.STYLE_FONTSTYLE] = mxConstants.FONT_BOLD + mxConstants.FONT_ITALIC;
+        userTaskStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+        userTaskStyle[StyleIdentifiers.STYLE_FONTSIZE] = '14';
+        userTaskStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_BOLD + FontStyle.FONT_ITALIC;
     }
 }
 

--- a/examples/static/js/style-identifiers.js
+++ b/examples/static/js/style-identifiers.js
@@ -1,5 +1,5 @@
 /**
- * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
  */
 class StyleIdentifiers {
     static STYLE_FILLCOLOR = 'fillColor';
@@ -17,7 +17,7 @@ class StyleIdentifiers {
 }
 
 /**
- * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
  */
 class Directions {
     static DIRECTION_EAST = 'east';
@@ -26,7 +26,7 @@ class Directions {
 }
 
 /**
- * Substitute mxGraph mxConstants available when using the mxgraph dependency. This is not available when using the IIFE bpmn-visualization bundle.
+ * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
  */
 class FontStyle {
     static FONT_BOLD = 1;


### PR DESCRIPTION
We don't provide a way to get the mxGraph `mxConstants` but we documented it in some README files.
So instead, we now explain where the style keys and values can be found in the mxGraph documentation and how to use them in the `bpmn-visualization` context.

### Notes
This work was started with #243, there were still some references to mxConstants in README
See also feedback in https://github.com/process-analytics/bpmn-visualization-examples/issues/294#issuecomment-1047258908

