### PR TITLE
[FIX] Fix the page title of 2 custom behavior examples

### DIFF
--- a/examples/custom-behavior/growing-sequence-flow/index.html
+++ b/examples/custom-behavior/growing-sequence-flow/index.html
@@ -15,7 +15,7 @@ limitations under the License.
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <title>BPMN Visualization - Diagram Navigation</title>
+        <title>BPMN Visualization - Growing Sequence Flow</title>
         <link rel="icon" href="../../favicon.png">
         <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
         <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">

--- a/examples/custom-behavior/running-dashed-message-flow/index.html
+++ b/examples/custom-behavior/running-dashed-message-flow/index.html
@@ -15,7 +15,7 @@ limitations under the License.
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <title>BPMN Visualization - Diagram Navigation</title>
+        <title>BPMN Visualization - Running Dashed Message Flow</title>
         <link rel="icon" href="../../favicon.png">
         <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
         <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">


### PR DESCRIPTION
Use the same text as in the page.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix/custom_behaviour_title_of_pages/examples/index.html

