### PR TITLE
 [REFACTOR] Load scripts using the defer attribute

### DIFF
--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -24,6 +24,18 @@ limitations under the License.
     <link rel="stylesheet" href="../static/css/controls.css" type="text/css">
     <link rel="stylesheet" href="../static/css/use-case.css" type="text/css">
     <link rel="stylesheet" href="../static/css/bpmn-container.css" type="text/css">
+    <script defer src="../../examples/static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- load the example -->
+    <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="../../examples/static/js/style-identifiers.js"></script>
+    <script defer src="../static/js/use-case.js"></script>
+    <script defer src="js/theme.js"></script>
+    <script defer src="js/theme-bpmn-visualization.js"></script>
+    <script defer src="js/use-case/hacktoberfest-use-case.js"></script>
+    <script defer src="js/use-case/theme-use-case.js"></script>
+    <script defer src="js/index.js"></script>
 </head>
 <body>
 <header class="navbar bg-dark p-2">
@@ -116,18 +128,5 @@ limitations under the License.
         </div>
     </div>
 </section>
-
-<script src="../../examples/static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-<!-- load the example -->
-<script src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
-<script src="../../examples/static/js/style-identifiers.js"></script>
-<script src="../static/js/use-case.js"></script>
-<script src="js/theme.js"></script>
-<script src="js/theme-bpmn-visualization.js"></script>
-<script src="js/use-case/hacktoberfest-use-case.js"></script>
-<script src="js/use-case/theme-use-case.js"></script>
-<script src="js/index.js"></script>
 </body>
 </html>

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -40,7 +40,8 @@ limitations under the License.
     <script defer src="js/execution-data/time-execution-data.js"></script>
     <script defer src="js/execution-data/frequency-execution-data.js"></script>
     <script defer src="js/monitoring-use-case.js"></script>
-    <script defer src="./js/index.js"></script></head>
+    <script defer src="./js/index.js"></script>
+</head>
 <body>
 <header class="navbar bg-dark p-2">
     <section class="navbar-section ml-2">

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -26,7 +26,21 @@ limitations under the License.
     <link rel="stylesheet" href="../static/css/bpmn-container.css" type="text/css">
     <link rel="stylesheet" href="./css/path.css" type="text/css">
     <link rel="stylesheet" href="./css/legend.css" type="text/css">
-</head>
+    <script defer src="../../examples/static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
+            crossorigin="anonymous"></script>
+    <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>
+    <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="../static/js/use-case.js"></script>
+    <script defer src="js/execution-data/utils.js"></script>
+    <script defer src="./js/legend.js"></script>
+    <script defer src="js/execution-data/execution-data.js"></script>
+    <script defer src="js/execution-data/time-execution-data.js"></script>
+    <script defer src="js/execution-data/frequency-execution-data.js"></script>
+    <script defer src="js/monitoring-use-case.js"></script>
+    <script defer src="./js/index.js"></script></head>
 <body>
 <header class="navbar bg-dark p-2">
     <section class="navbar-section ml-2">
@@ -144,21 +158,5 @@ limitations under the License.
         </div>
     </div>
 </section>
-
-<script src="../../examples/static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
-        crossorigin="anonymous"></script>
-<script src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>
-<script src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
-<script src="../static/js/use-case.js"></script>
-<script src="js/execution-data/utils.js"></script>
-<script src="./js/legend.js"></script>
-<script src="js/execution-data/execution-data.js"></script>
-<script src="js/execution-data/time-execution-data.js"></script>
-<script src="js/execution-data/frequency-execution-data.js"></script>
-<script src="js/monitoring-use-case.js"></script>
-<script src="./js/index.js"></script>
 </body>
 </html>

--- a/examples/custom-behavior/apply-css-classes/index.html
+++ b/examples/custom-behavior/apply-css-classes/index.html
@@ -86,6 +86,10 @@ limitations under the License.
             fill-opacity: 40% !important;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
     <header class="navbar bg-dark p-2">
@@ -151,10 +155,5 @@ limitations under the License.
     <section class="col-11 mt-2 relative">
         <div id="bpmn-container"></div>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
-    <script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-behavior/call-activity-with-modal-on-mouse-over/index.html
+++ b/examples/custom-behavior/call-activity-with-modal-on-mouse-over/index.html
@@ -32,6 +32,12 @@ limitations under the License.
                 overflow: hidden;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
+        <script defer src="./modal.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -79,12 +85,5 @@ limitations under the License.
                 <div class="modal-footer"></div>
             </div>
         </div>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
-        <script src="./modal.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/call-activity-with-reload-on-dblclick/index.html
+++ b/examples/custom-behavior/call-activity-with-reload-on-dblclick/index.html
@@ -34,6 +34,12 @@ limitations under the License.
                 background-color: white;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
+        <script defer src="./breadcrumbs.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -72,12 +78,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
-        <script src="./breadcrumbs.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/call-activity-with-tabs-on-click/index.html
+++ b/examples/custom-behavior/call-activity-with-tabs-on-click/index.html
@@ -34,6 +34,11 @@ limitations under the License.
                 background-color: white;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -74,11 +79,5 @@ limitations under the License.
                 <div id="secondary-bpmn-container" class="column col-12 col-mx-auto bpmn-container d-hide"></div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/growing-sequence-flow/index.html
+++ b/examples/custom-behavior/growing-sequence-flow/index.html
@@ -55,6 +55,11 @@ limitations under the License.
                 }
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -88,11 +93,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.html
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.html
@@ -43,6 +43,16 @@ limitations under the License.
                 font-family: monospace;
             }
         </style>
+        <!-- Popover and Tooltip support -->
+        <script defer src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha256-WgfGn5Bh6xLjmgMTWKT1Z/MKACrWGCY5rIT9G9ovbmU=" crossorigin="anonymous"></script>
+        <!-- Development version -->
+        <script defer src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.1/dist/tippy-bundle.umd.js" integrity="sha256-mII5pSbIKUGuLuv63S7irex7OpIvGzxRkcXP+jOAIu4=" crossorigin="anonymous"></script>
+
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -81,16 +91,5 @@ limitations under the License.
         <section class="col-11 relative" style="margin-top: 2em">
             <div id="bpmn-container"></div>
         </section>
-
-        <!-- Popover and Tooltip support -->
-        <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha256-WgfGn5Bh6xLjmgMTWKT1Z/MKACrWGCY5rIT9G9ovbmU=" crossorigin="anonymous"></script>
-        <!-- Development version -->
-        <script src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.1/dist/tippy-bundle.umd.js" integrity="sha256-mII5pSbIKUGuLuv63S7irex7OpIvGzxRkcXP+jOAIu4=" crossorigin="anonymous"></script>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="index.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/popover-static/index.html
+++ b/examples/custom-behavior/popover-static/index.html
@@ -65,6 +65,12 @@ limitations under the License.
                 height: 150px;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="../../static/js/dom-helper.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -115,12 +121,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="../../static/js/dom-helper.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/running-dashed-message-flow/index.html
+++ b/examples/custom-behavior/running-dashed-message-flow/index.html
@@ -55,6 +55,11 @@ limitations under the License.
                 }
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -88,11 +93,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -54,6 +54,14 @@ limitations under the License.
             display: none !important;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-a_4_1.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_0.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_2_0.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/notyf@3.9.0/notyf.min.js" integrity="sha256-94ygrajpwhaqxLOwPjuOZSUlCJ/KdtFefKg+Iu3WCAk=" crossorigin="anonymous"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
     <header class="navbar bg-dark p-2">
@@ -130,14 +138,5 @@ limitations under the License.
     <section class="col-11 mt-2 relative">
         <div id="bpmn-container"></div>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-a_4_1.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_0.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_2_0.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/notyf@3.9.0/notyf.min.js" integrity="sha256-94ygrajpwhaqxLOwPjuOZSUlCJ/KdtFefKg+Iu3WCAk=" crossorigin="anonymous"></script>
-    <script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -26,7 +26,8 @@ limitations under the License.
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../../static/js/style-identifiers.js"></script>
-    <script defer src="index.js"></script></head>
+    <script defer src="index.js"></script>
+</head>
 <body>
     <header class="navbar bg-dark p-2">
         <section class="navbar-section ml-2">

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -20,7 +20,13 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-</head>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- load the example -->
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="../../static/js/style-identifiers.js"></script>
+    <script defer src="index.js"></script></head>
 <body>
     <header class="navbar bg-dark p-2">
         <section class="navbar-section ml-2">
@@ -75,13 +81,5 @@ limitations under the License.
 
             </section>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <!-- load bpmn-visualization -->
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <!-- load the example -->
-    <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script src="../../static/js/style-identifiers.js"></script>
-    <script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-bpmn-theme/custom-fonts/index.html
+++ b/examples/custom-bpmn-theme/custom-fonts/index.html
@@ -20,6 +20,13 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- load the example -->
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="../../static/js/style-identifiers.js"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
 
@@ -60,13 +67,5 @@ limitations under the License.
 
         </section>
 </section>
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-<!-- load the example -->
-<script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-<script src="../../static/js/style-identifiers.js"></script>
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/custom-bpmn-theme/custom-user-task-icon/index.html
+++ b/examples/custom-bpmn-theme/custom-user-task-icon/index.html
@@ -20,6 +20,12 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- load the example -->
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
 
@@ -55,12 +61,5 @@ limitations under the License.
 
         </section>
 </section>
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-<!-- load the example -->
-<script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/diagram-navigation/diagram-fit-after-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-after-load/index.html
@@ -51,6 +51,11 @@ limitations under the License.
             display: none !important;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
     <header class="navbar bg-dark p-2">
@@ -130,12 +135,5 @@ limitations under the License.
                 </div>
             </section>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <!-- load bpmn-visualization -->
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-
-    <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script src="index.js"></script>
 </body>
 </html>

--- a/examples/diagram-navigation/diagram-fit-on-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-on-load/index.html
@@ -38,6 +38,11 @@ limitations under the License.
                 margin-top: 0;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -104,11 +109,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="index.js"></script>
     </body>
 </html>

--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -33,6 +33,10 @@ limitations under the License.
             overflow: hidden;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="./index.js"></script>
 </head>
 <body>
     <header class="navbar bg-dark p-2">
@@ -78,10 +82,5 @@ limitations under the License.
                 </div>
             </section>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script src="./index.js"></script>
 </body>
 </html>

--- a/examples/display-bpmn-diagram/01-getting-started/index.html
+++ b/examples/display-bpmn-diagram/01-getting-started/index.html
@@ -20,9 +20,15 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- if you prefer unpkg, comment the previous line and uncomment the following line -->
+    <!--<script defer src="https://unpkg.com/browse/bpmn-visualization@0.21.5/dist//bpmn-visualization.min.js"></script>-->
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="./index.js"></script>
 </head>
 <body>
-
 <header class="navbar bg-dark p-2">
     <section class="navbar-section ml-2">
         <a class="home" href="../../index.html">
@@ -50,16 +56,5 @@ limitations under the License.
         </div>
     </section>
 </section>
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-<!-- if you prefer unpkg, comment the previous line and uncomment the following line -->
-<!--<script src="https://unpkg.com/browse/bpmn-visualization@0.21.5/dist//bpmn-visualization.min.js"></script>-->
-<script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-<script>
-    const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container' });
-    bpmnVisualization.load(getGettingStartedBpmnDiagram());
-</script>
 </body>
 </html>

--- a/examples/display-bpmn-diagram/01-getting-started/index.js
+++ b/examples/display-bpmn-diagram/01-getting-started/index.js
@@ -1,0 +1,2 @@
+const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container' });
+bpmnVisualization.load(getGettingStartedBpmnDiagram());

--- a/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
@@ -51,7 +51,8 @@ limitations under the License.
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <script defer src="index.js"></script></head>
+    <script defer src="index.js"></script>
+</head>
 <body>
 
 <header class="navbar bg-dark p-2">

--- a/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
@@ -48,7 +48,10 @@ limitations under the License.
             display: none !important;
         }
     </style>
-</head>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="index.js"></script></head>
 <body>
 
 <header class="navbar bg-dark p-2">
@@ -88,11 +91,5 @@ limitations under the License.
         <div id="bpmn-container" class="mb-2"></div>
     </div>
 </section>
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
@@ -58,6 +58,10 @@ limitations under the License.
             display: none !important;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <script defer src="index.js"></script>
 </head>
 <body>
 
@@ -105,11 +109,5 @@ limitations under the License.
         <div id="bpmn-container" class="mb-2"></div>
     </div>
 </section>
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -20,7 +20,6 @@ limitations under the License.
   <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
   <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
   <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-
   <style>
     .bpmn-container {
       /*top: 60px;*/
@@ -56,6 +55,13 @@ limitations under the License.
       padding-top: 0.5em;
     }
   </style>
+  <script defer src="../../static/js/link-to-sources.js"></script>
+  <!-- load bpmn-js viewer distro (with pan and zoom) -->
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@8.9.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-6sVdF06e3b7gVOOVyEZYtZIjq0mzMxjBSbjiOFDXdFo=" crossorigin="anonymous"></script>
+  <!-- load bpmn-visualization -->
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+  <script defer src="shared.js"></script>
+  <script defer src="index.js"></script>
 </head>
 <body>
 
@@ -117,15 +123,5 @@ limitations under the License.
   <div id="container-bpmn-visualization" class="bpmn-container"></div>
   <div id="container-bpmn-js" class="bpmn-container hidden"></div>
 </section>
-
-
-<script src="../../static/js/link-to-sources.js"></script>
-<!-- load bpmn-js viewer distro (with pan and zoom) -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-js@8.9.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-6sVdF06e3b7gVOOVyEZYtZIjq0mzMxjBSbjiOFDXdFo=" crossorigin="anonymous"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-
-<script src="shared.js"></script>
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -20,7 +20,6 @@ limitations under the License.
   <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
   <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
   <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-
   <style>
     .bpmn-container {
       /*top: 60px;*/
@@ -55,6 +54,14 @@ limitations under the License.
       padding-top: 0.5em;
     }
   </style>
+  <script defer src="../../static/js/link-to-sources.js"></script>
+  <script defer src="../../static/js/dom-helper.js"></script>
+  <!-- load bpmn kie-editors-standalone -->
+  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.16.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>
+  <!-- load bpmn-visualization -->
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+  <script defer src="../compare-with-bpmn-js/shared.js"></script>
+  <script defer src="index.js"></script>
 </head>
 <body>
 
@@ -118,16 +125,5 @@ limitations under the License.
   <div id="container-bpmn-visualization" class="bpmn-container"></div>
   <div id="container-kie-editors-standalone" class="bpmn-container hidden"></div>
 </section>
-
-
-<script src="../../static/js/link-to-sources.js"></script>
-<script src="../../static/js/dom-helper.js"></script>
-<!-- load bpmn kie-editors-standalone -->
-<script src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.16.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>
-<!-- load bpmn-visualization -->
-<script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-
-<script src="../compare-with-bpmn-js/shared.js"></script>
-<script src="index.js"></script>
 </body>
 </html>

--- a/examples/overlays/add-remove/index.html
+++ b/examples/overlays/add-remove/index.html
@@ -46,6 +46,11 @@ limitations under the License.
                 margin-top: 2em;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -251,11 +256,5 @@ limitations under the License.
                 </div>
             </section>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/overlays/add-stylized/index.html
+++ b/examples/overlays/add-stylized/index.html
@@ -41,6 +41,11 @@ limitations under the License.
                 min-width: 200px;
             }
         </style>
+        <script defer src="../../static/js/link-to-sources.js"></script>
+        <!-- load bpmn-visualization -->
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+        <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+        <script defer src="./index.js"></script>
     </head>
     <body>
         <header class="navbar bg-dark p-2">
@@ -114,11 +119,5 @@ limitations under the License.
                 </div>
             </div>
         </section>
-
-        <script src="../../static/js/link-to-sources.js"></script>
-        <!-- load bpmn-visualization -->
-        <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-        <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-        <script src="./index.js"></script>
     </body>
 </html>

--- a/examples/overlays/custom-overlay-default-style/index.html
+++ b/examples/overlays/custom-overlay-default-style/index.html
@@ -20,7 +20,6 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-
     <style>
         .bpmn-container {
             /* use absolute values for height to ensure that the vertical diagram is not fully displayed when the page is opened. */
@@ -28,6 +27,12 @@ limitations under the License.
             height: 200px;
         }
     </style>
+    <script defer src="../../static/js/link-to-sources.js"></script>
+    <!-- load bpmn-visualization -->
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
+    <!-- load the example -->
+    <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
+    <script defer src="./index.js"></script>
 </head>
 <body>
     <header class="navbar bg-dark p-2">
@@ -68,12 +73,5 @@ limitations under the License.
 
             </section>
     </section>
-
-    <script src="../../static/js/link-to-sources.js"></script>
-    <!-- load bpmn-visualization -->
-    <script src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.21.5/dist/bpmn-visualization.min.js"></script>
-    <!-- load the example -->
-    <script src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script src="./index.js"></script>
 </body>
 </html>

--- a/examples/projects/typescript-vanilla-with-rollup/src/index.html
+++ b/examples/projects/typescript-vanilla-with-rollup/src/index.html
@@ -5,6 +5,8 @@
     <title>BPMN Visualization TypeScript Integration</title>
     <link href="static/css/main.css" rel="stylesheet">
     <link rel="icon" href="static/img/favicon.png">
+    <!-- load demo -->
+    <script src="index.esm.js" type="module"></script>
 </head>
 <body>
     <header class="info-centered">
@@ -14,8 +16,5 @@
         <!-- container used to display the BPMN diagram -->
         <div id="bpmn-container"></div>
     </section>
-
-    <!-- load demo -->
-    <script src="index.esm.js" type="module"></script>
 </body>
 </html>

--- a/examples/projects/typescript-vanilla-with-vitejs/index.html
+++ b/examples/projects/typescript-vanilla-with-vitejs/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
+    <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
     <div id="app"></div>
     <div id="bpmn-container"></div>
-    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
closes #267

Tasks
- [x] demo
- examples
  - [x] custom-behavior
  - [x] custom-bpmn-theme
  - [x] diagram-navigation
  - [x] display-bpmn-diagram
     - getting started: I introduced an index.js script because defer has no effect on inline script, see https://developer.mozilla.org/en-US/docs/web/html/element/script#attr-defer
  - [x] misc
  - [x] overlays
- projects
  - [x] rollup: move from body to head (use module type, so defer)
  - [x] vite: move from body to head (use module type, so defer)
  - webpack: nothing to do, script is injected by webpack

**For testers**
I tested locally.
We need to ensure everything works fine with statically.io


**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/267-load_js_file_with_defer/examples/index.html
