### PR TITLE
[FEAT] Add more links to GH sources in titles

### DIFF
--- a/examples/static/js/link-to-sources.js
+++ b/examples/static/js/link-to-sources.js
@@ -1,16 +1,46 @@
-// we want to transform
-// https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/173d6e7db380f74e61c98c43460d1642852e9d37/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html
-// into
-// https://github.com/process-analytics/bpmn-visualization-examples/tree/173d6e7db380f74e61c98c43460d1642852e9d37/examples/custom-navigation/call-activity-with-modal-on-mouse-over
-if (window.location.hostname === 'cdn.statically.io') {
-    // get the part after the 4th slash
-    const part = window.location.pathname.split('/').slice(4).join('/');
-    // and remove the file part
-    const indexLastSlash = part.lastIndexOf('/');
-    const finalPath = part.substring(0, indexLastSlash);
-    const githubHref = `https://github.com/process-analytics/bpmn-visualization-examples/tree/${finalPath}`;
+const logLinkToGithub = (msg) => {
+    console.info('[Link to GH]', msg);
+}
 
-    const titleWithGhLinkElt = document.querySelector('section h2');
-    titleWithGhLinkElt.innerHTML = `${titleWithGhLinkElt.innerHTML} <a href="${githubHref}" title="View the source code on GitHub" style="text-decoration: none"><img src="https://github.githubassets.com/favicons/favicon.png" alt="github logo"></a>`;
-    console.info('Title updated with link to GH sources!');
+let subPath;
+if (window.location.hostname === 'cdn.statically.io') {
+    logLinkToGithub('Statically.io environment detected')
+    // get the subPath after the 4th slash (everything after https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/)
+    // for example, from https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/173d6e7db380f74e61c98c43460d1642852e9d37/examples/custom-navigation/call-activity-with-modal-on-mouse-over/index.html
+    subPath = window.location.pathname.split('/').slice(4).join('/');
+}
+// local environment: webserver or file browsing
+// <interesting_part> contains demo or examples in file://path/<interesting_part> or http://localhost:port/<interesting_part>
+else if (window.location.hostname === 'localhost' || window.location.protocol.startsWith('file')) {
+    logLinkToGithub('Local environment detected')
+    const pathname = window.location.pathname;
+    // we keep everything after the latest occurrence of /examples/ or /demo/
+    let lastIndexOfInterestingElement = pathname.lastIndexOf('/examples/');
+    if (lastIndexOfInterestingElement === -1) {
+        lastIndexOfInterestingElement = pathname.lastIndexOf('/demo/');
+    }
+    if (lastIndexOfInterestingElement !== -1) {
+        // force link to master
+        subPath = `master${pathname.substring(lastIndexOfInterestingElement)}`;
+    }
+}
+
+if (subPath) {
+    // remove the file at the end of the path subPath to create a link like
+    // // https://github.com/process-analytics/bpmn-visualization-examples/tree/173d6e7db380f74e61c98c43460d1642852e9d37/examples/custom-navigation/call-activity-with-modal-on-mouse-over
+    const indexLastSlash = subPath.lastIndexOf('/');
+    const finalPath = subPath.substring(0, indexLastSlash);
+    const githubHref = `https://github.com/process-analytics/bpmn-visualization-examples/tree/${finalPath}`;
+    // the IDE the source of the current page
+    const githubDevHref = `https://github.dev/process-analytics/bpmn-visualization-examples/tree/${subPath}`;
+
+    const logoDimensionsDirective = 'width="32px" height="32px"';
+    const anchorEltToGhSources = `<a href="${githubHref}" title="View the source code on GitHub" style="text-decoration: none"><img src="https://github.githubassets.com/favicons/favicon.png" alt="github logo" ${logoDimensionsDirective}></a>`;
+    const anchorEltToGhDev = `<a href="${githubDevHref}" title="Edit the source code on GitHub DEV" style="text-decoration: none"><img src="https://github.com/LukyVj/dev-logos/raw/e1bde4a2e2acb31fb2bc61c8f34bd1fb5508e128/vs-code_logo.svg" alt="github codespaces logo" ${logoDimensionsDirective}></a>`;
+    const titleWithGhLinkElements = document.querySelectorAll('section h2');
+    titleWithGhLinkElements.forEach(titleWithGhLinkElt => {
+        titleWithGhLinkElt.innerHTML = `${titleWithGhLinkElt.innerHTML} ${anchorEltToGhSources} ${anchorEltToGhDev}`
+    });
+
+    logLinkToGithub('Title(s) updated with link to GH sources and GH dev!');
 }


### PR DESCRIPTION
Add a link in all h2 title that exist in the page
Add a link with custom icon to edit on github.dev
Create the links when running locally (file browsing and dev server)

closes #270 
closes #272 

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/49ae2291c842a9fc0c8874b906a41190b226d713/examples/index.html

**Implementation notes**

I wasn't sure when choosing the logo to github.dev. The official favicon is https://github.com/favicons/favicon-codespaces.svg but it looks to close from the GH logo. In a first implementation, I dedice to use the VSCode logo

![image](https://user-images.githubusercontent.com/27200110/155935836-37aa03cf-1ab6-4caf-ac1b-7849912a5b59.png)
_github.dev favicon_


