### PR TITLE
[FEAT] Disable pool collapsing

### DIFF
--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -89,8 +89,10 @@ limitations under the License.
             <div class="col-12 mb-2">
                 <h2>Select elements by BPMN kind</h2>
                 Once the BPMN diagram is loaded, detect all <code>Pools</code> and <code>End Events</code>.<br>
-                Then, use this information to select <code>Pools</code> (hide or collapse) and make <code>End Events</code> clickable
-                (as far as no <code>Pools</code> selection is done. Toast support <a href="https://github.com/caroso1222/notyf">Notyf</a>).
+                Then, use this information to select <code>Pools</code> (hide) and make <code>End Events</code>
+                clickable
+                (as far as no <code>Pools</code> selection is done. Toast support <a
+                    href="https://github.com/caroso1222/notyf">Notyf</a>).
             </div>
             <div id="controls" style="margin-top: 25px" >
                 <div class="col-3 float-left">
@@ -116,9 +118,11 @@ limitations under the License.
                             <div class="radio">
                                 <label><input type="radio" name="poolSelectionMethod" value="hide" checked> Hide others</label>
                             </div>
+                            <!-- Disable collapsing: see https://github.com/process-analytics/bpmn-visualization-examples/pull/306
                             <div class="radio">
                                 <label><input type="radio" name="poolSelectionMethod" value="collapse"> Collapse others</label>
                             </div>
+                            -->
                         </div>
                     </div>
                     <div id="pool-selection-info" class="col-5 float-left hidden">

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -89,10 +89,8 @@ limitations under the License.
             <div class="col-12 mb-2">
                 <h2>Select elements by BPMN kind</h2>
                 Once the BPMN diagram is loaded, detect all <code>Pools</code> and <code>End Events</code>.<br>
-                Then, use this information to select <code>Pools</code> (hide) and make <code>End Events</code>
-                clickable
-                (as far as no <code>Pools</code> selection is done. Toast support <a
-                    href="https://github.com/caroso1222/notyf">Notyf</a>).
+                Then, use this information to select <code>Pools</code> (hide) and make <code>End Events</code> clickable
+                (as far as no <code>Pools</code> selection is done. Toast support <a href="https://github.com/caroso1222/notyf">Notyf</a>).
             </div>
             <div id="controls" style="margin-top: 25px" >
                 <div class="col-3 float-left">

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -89,7 +89,7 @@ limitations under the License.
             <div class="col-12 mb-2">
                 <h2>Select elements by BPMN kind</h2>
                 Once the BPMN diagram is loaded, detect all <code>Pools</code> and <code>End Events</code>.<br>
-                Then, use this information to select <code>Pools</code> (hide) and make <code>End Events</code> clickable
+                Then, use this information to select <code>Pools</code> (hide others) and make <code>End Events</code> clickable
                 (as far as no <code>Pools</code> selection is done. Toast support <a href="https://github.com/caroso1222/notyf">Notyf</a>).
             </div>
             <div id="controls" style="margin-top: 25px" >
@@ -111,18 +111,18 @@ limitations under the License.
                         <ul class="menu custom-dropdown" id="dropdown-select-pool">
                         </ul>
                     </div>
+                    <!-- Disable collapsing: see https://github.com/process-analytics/bpmn-visualization-examples/pull/306
                     <div class="col-3 float-left">
                         <div class="align-middle">
                             <div class="radio">
                                 <label><input type="radio" name="poolSelectionMethod" value="hide" checked> Hide others</label>
                             </div>
-                            <!-- Disable collapsing: see https://github.com/process-analytics/bpmn-visualization-examples/pull/306
                             <div class="radio">
                                 <label><input type="radio" name="poolSelectionMethod" value="collapse"> Collapse others</label>
                             </div>
-                            -->
                         </div>
                     </div>
+                    -->
                     <div id="pool-selection-info" class="col-5 float-left hidden">
                         <b>Last selected Pool:</b> <span id="last-selected-pool-name"></span>
                     </div>

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.js
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.js
@@ -124,7 +124,9 @@ function changePoolsVisibility(pools, poolIdToHighlight) {
   console.info('Updating model, pool to highlight:', poolIdToHighlight);
   const model = bpmnVisualization.graph.getModel();
 
-  const poolSelectionMethod = getRadioGroupValue('poolSelectionMethod');
+  // TMP disable collapsing other pools, see https://github.com/process-analytics/bpmn-visualization-examples/pull/306
+  // const poolSelectionMethod = getRadioGroupValue('poolSelectionMethod');
+  const poolSelectionMethod = 'hide';
   console.info('Selection method:', poolSelectionMethod);
   const hideOthers = poolSelectionMethod === 'hide';
   const modelChangeFunction = hideOthers ?


### PR DESCRIPTION
The upcoming bpmn-visualization version changes the edge rendering. There is no more usage of the Segment Connector.
This setting was recomputing the whole edge path. It was able to set the terminal waypoints to the collapsed pools when
the edge was targeting a inner element of the pool (hidden when the pool is collapsed).
There is no more waypoints' computation with the new implementation: in this case, we see a dangling edge. The edge
terminal waypoint are inside the pool.

See #306 and https://github.com/process-analytics/bpmn-visualization-js/pull/1863#issuecomment-1070819537

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/disable_pools_collapsing/examples/index.html