### PR TITLE
[FEAT] Display the lib version in the html page footer (demos)

### DIFF
--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -69,7 +69,7 @@ limitations under the License.
             </p>
         </div>
 
-        <div class="column col-11 col-mx-auto" style="margin-top: 2rem; margin-bottom: 1rem">
+        <div class="column col-11 col-mx-auto" style="margin-top: 1rem; margin-bottom: 1rem">
             <div id="controls" class="column bg-secondary pt-2 pb-2">
                 <div class="columns">
                     <div class="column col-4">
@@ -125,5 +125,6 @@ limitations under the License.
         </div>
     </div>
 </section>
+<footer class="flex-centered"></footer>
 </body>
 </html>

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -156,5 +156,6 @@ limitations under the License.
         </div>
     </div>
 </section>
+<footer class="flex-centered"></footer>
 </body>
 </html>

--- a/demo/predictions/index.html
+++ b/demo/predictions/index.html
@@ -96,5 +96,6 @@ limitations under the License.
         </div>
     </div>
 </section>
+<footer class="flex-centered"></footer>
 </body>
 </html>

--- a/demo/static/css/style.css
+++ b/demo/static/css/style.css
@@ -115,3 +115,13 @@
     padding-top: 1rem;
     padding-bottom: 1rem;
 }
+
+/* ************************************* */
+/* Footer */
+/* ************************************* */
+footer {
+    margin-bottom: 0.5rem;
+    font-size: small;
+    font-style: italic;
+}
+

--- a/demo/static/js/use-case.js
+++ b/demo/static/js/use-case.js
@@ -22,10 +22,19 @@ class UseCase {
 
         if (!this.#alreadyLoad) {
             this._bpmnVisualization = this._initBpmnVisualization({container: `${this.#type}-bpmn-container`, navigation: {enabled: this.#navigationEnabled}});
+            this._displayVersionInfoInFooter(); // This is called by each use case available in the page, but this is not an issue. All use the same bpmn-visualization version
             this._preLoadDiagram();
             this._bpmnVisualization.load(this.#getDiagram(), this.#loadOptions);
             this._postLoadDiagram();
             this.#alreadyLoad = true;
+        }
+    }
+
+    _displayVersionInfoInFooter() {
+        const footerElt = document.querySelector('footer');
+        if (footerElt) {
+            const version = this._bpmnVisualization.getVersion();
+            footerElt.innerText = `bpmn-visualization@${version.lib}`;
         }
     }
 


### PR DESCRIPTION
based on #297

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bpmn-visualization_version_in_footer_of_demos/examples/index.html

### Screenshots

The unreleased "predictions" demo has also been updated.

demo | before | now
---- | ---- | ---- 
hacktoberfest | ![image](https://user-images.githubusercontent.com/27200110/177763601-fd2620e1-4817-499f-bb89-bf4ddc236857.png) | ![image](https://user-images.githubusercontent.com/27200110/177763982-72651779-6736-48c1-b48b-4bd1cea8d0bf.png) |
monitoring | ![image](https://user-images.githubusercontent.com/27200110/177764126-331059b6-c161-4d5f-ae86-e618b086a28f.png) | ![image](https://user-images.githubusercontent.com/27200110/177763737-bbf2b664-22d1-48f6-a4ff-262b4f0743b2.png) |
