### PR TITLE
[FEAT] Bump kie-editors-standalone from 0.16.0 to 0.18.0 in the misc example

### DIFF
--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,10 +57,8 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <!--  TODO put integrity when available on jsdelivr -->
-  <!--  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.17.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>-->
-  <script defer src="https://unpkg.com/@kie-tools/kie-editors-standalone@0.18.0/dist/bpmn/index.js"
-          crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.18.0/dist/bpmn/index.js"
+          integrity="sha256-yo/v73FGXu9S4B7+3KDqnlVNL+L5lg3okbHD53drLHQ=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.23.0/dist/bpmn-visualization.min.js"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,7 +57,8 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.16.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>
+<!--  TODO put integrity when available + @kie-tools -->
+  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.17.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.23.0/dist/bpmn-visualization.min.js"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -50,7 +50,6 @@ limitations under the License.
       float: left;
       margin-left: 1em;
     }
-
     .labels {
       padding-top: 0.5em;
     }

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -50,6 +50,7 @@ limitations under the License.
       float: left;
       margin-left: 1em;
     }
+
     .labels {
       padding-top: 0.5em;
     }
@@ -57,8 +58,10 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-<!--  TODO put integrity when available + @kie-tools -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.17.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>
+  <!--  TODO put integrity when available on jsdelivr -->
+  <!--  <script defer src="https://cdn.jsdelivr.net/npm/@kogito-tooling/kie-editors-standalone@0.17.0/dist/bpmn/index.js" integrity="sha256-sWAO7AzUXClUPIr5JDK6E0JQsNHpJRKb/39oH18MZJY=" crossorigin="anonymous"></script>-->
+  <script defer src="https://unpkg.com/@kie-tools/kie-editors-standalone@0.18.0/dist/bpmn/index.js"
+          crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.23.0/dist/bpmn-visualization.min.js"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
I haven't noticed changes about console errors: there are still a lot!

closes #304

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bump_kie_to_0.18.0/examples/index.html
