### PR TITLE
[REFACTOR] Simplify mxGraph initialization in vite TS project

### DIFF
--- a/examples/projects/typescript-vanilla-with-vitejs/src/main.ts
+++ b/examples/projects/typescript-vanilla-with-vitejs/src/main.ts
@@ -2,6 +2,7 @@ import './style.css'
 // this is simple example of the BPMN diagram, loaded as string
 import diagram from './diagram.bpmn?raw'
 import { BpmnVisualization } from 'bpmn-visualization';
+// put this import after the 'BpmnVisualization' import to ensure mxGraph is correctly configured by bpmn-visualization
 import { mxgraph } from "./mxgraph-intializer";
 
 // instantiate BpmnVisualization, pass the container HTMLElement - present in index.html

--- a/examples/projects/typescript-vanilla-with-vitejs/src/mxgraph-intializer.ts
+++ b/examples/projects/typescript-vanilla-with-vitejs/src/mxgraph-intializer.ts
@@ -1,7 +1,7 @@
 import factory, {type mxGraphExportObject} from 'mxgraph';
 
-// The following is needed if you need to access to mxGraph value objects that are required to instantiate mxGraph objects or extending the mxGraph code.
-// It is not necessary if you only need to directly use mxGraph in your code.
+// The following is only needed when you access to mxGraph value objects. They are necessary to instantiate or extend mxGraph objects.
+// You don't need it if you don't directly use mxGraph in your code.
 
 export const mxgraph = initialize();
 

--- a/examples/projects/typescript-vanilla-with-vitejs/src/mxgraph-intializer.ts
+++ b/examples/projects/typescript-vanilla-with-vitejs/src/mxgraph-intializer.ts
@@ -1,18 +1,11 @@
 import factory, {type mxGraphExportObject} from 'mxgraph';
 
-// The following is taken from bpmn-visualization
-// It demonstrates how to access to mxGraph value objects that are required to instantiate mxGraph objects or extending the mxGraph code.
-// It is not necessary if you only need to use mxGraph types.
+// The following is needed if you need to access to mxGraph value objects that are required to instantiate mxGraph objects or extending the mxGraph code.
+// It is not necessary if you only need to directly use mxGraph in your code.
 
 export const mxgraph = initialize();
 
-// Taken from the bpmn-visualization code
 function initialize(): mxGraphExportObject {
-  // set options globally, as it is not working when passing options to the factory (https://github.com/jgraph/mxgraph/issues/479)
-  (window as any)['mxLoadResources'] = false;
-  (window as any)['mxLoadStylesheets'] = false;
-  // extras, otherwise we got 'Uncaught ReferenceError: assignment to undeclared variable mx...'
-  (window as any)['mxForceIncludes'] = false;
-  (window as any)['mxResourceExtension'] = '.txt';
+  // The mxGraph options are configured by bpmn-visualization, so there is no need to set them again globally.
   return factory({});
 }


### PR DESCRIPTION
No need to configure mxGraph globals as they are already configured by bpmn-visualization.