### PR TITLE
[FEAT] Bump BPMN vendor libs used in the misc examples

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@8.9.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-6sVdF06e3b7gVOOVyEZYtZIjq0mzMxjBSbjiOFDXdFo=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@9.0.3/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-s/JkRyhKsh/RvFnHOHaBixwQtMShax4mAzW+SKvQWMU=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.23.2/dist/bpmn-visualization.min.js"></script>
   <script defer src="shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,8 +57,8 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.18.0/dist/bpmn/index.js"
-          integrity="sha256-yo/v73FGXu9S4B7+3KDqnlVNL+L5lg3okbHD53drLHQ=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.19.0/dist/bpmn/index.js"
+          integrity="sha256-UdaL91gCjylebTtxFlegIp+wveYHJYriiFtZmd8ssDY=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.23.2/dist/bpmn-visualization.min.js"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
bpmn-js from 8.9.0 to 9.0.3
kie-editors-standalone from 0.18.0 to 0.19.0

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bump_bpmn_vendors_lib/examples/index.html
