### PR TITLE
[INFRA] Bump dependencies in integration projects

### DIFF
--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -14,9 +14,9 @@
     "bpmn-visualization": "0.23.2"
   },
   "devDependencies": {
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.52.1",
-    "webpack-cli": "^4.8.0",
-    "webpack-dev-server": "^4.2.0"
+    "html-webpack-plugin": "~5.5.0",
+    "webpack": "~5.72.1",
+    "webpack-cli": "~4.9.2",
+    "webpack-dev-server": "~4.9.0"
   }
 }

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -9,19 +9,19 @@
     "build": "rollup -c",
     "start": "rollup -cw --environment devMode:true"
   },
-  "devDependencies": {
-    "@rollup/plugin-node-resolve": "^13.2.1",
-    "rimraf": "^3.0.2",
-    "rollup": "^2.70.2",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-copy-watch": "^0.0.1",
-    "rollup-plugin-livereload": "^2.0.5",
-    "rollup-plugin-serve": "^1.1.0",
-    "rollup-plugin-typescript2": "^0.31.2",
-    "typescript": "^4.6.3"
-  },
   "dependencies": {
     "bpmn-visualization": "0.23.2"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "~13.3.0",
+    "rimraf": "~3.0.2",
+    "rollup": "~2.73.0",
+    "rollup-plugin-commonjs": "~10.1.0",
+    "rollup-plugin-copy": "~3.4.0",
+    "rollup-plugin-copy-watch": "~0.0.1",
+    "rollup-plugin-livereload": "~2.0.5",
+    "rollup-plugin-serve": "~1.1.0",
+    "rollup-plugin-typescript2": "~0.31.2",
+    "typescript": "~4.6.4"
   }
 }

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -12,7 +12,7 @@
     "bpmn-visualization": "0.23.2"
   },
   "devDependencies": {
-    "typescript": "^4.6.2",
-    "vite": "^2.8.6"
+    "typescript": "~4.6.4",
+    "vite": "~2.9.9"
   }
 }


### PR DESCRIPTION
Use the latest development dependencies
Only allow using more recent patch versions to ensure better compatibility.