### PR TITLE
[INFRA] dev - Bump @rollup/plugin-commonjs from 10.1.0 to 22.0.0

### DIFF
--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,10 +13,10 @@
     "bpmn-visualization": "0.23.3"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "~22.0.0",
     "@rollup/plugin-node-resolve": "~13.3.0",
     "rimraf": "~3.0.2",
     "rollup": "~2.73.0",
-    "rollup-plugin-commonjs": "~10.1.0",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",

--- a/projects/typescript-vanilla-with-rollup/rollup.config.js
+++ b/projects/typescript-vanilla-with-rollup/rollup.config.js
@@ -19,7 +19,7 @@ import copy from "rollup-plugin-copy";
 import copyWatch from "rollup-plugin-copy-watch";
 
 import typescript from "rollup-plugin-typescript2";
-import commonjs from "rollup-plugin-commonjs";
+import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import pkg from "./package.json";
 


### PR DESCRIPTION
The plugin was relocated from `rollup-plugin-commonjs` to `@rollup/plugin-commonjs` almost 3 years ago.