### PR TITLE
[REFACTOR] Define general CSS class names instead of specific ones

### DIFF
--- a/examples/custom-behavior/apply-css-classes/index.html
+++ b/examples/custom-behavior/apply-css-classes/index.html
@@ -40,23 +40,26 @@ limitations under the License.
             --color-highlight: #2c623c;
         }
 
-        .bpmn-activity-info > rect {
+        .bpmn-type-activity.highlight-info > rect {
             fill: blue !important;
             fill-opacity: 30% !important;
             stroke: blue;
         }
-        .bpmn-activity-success > rect {
+        .bpmn-type-activity.highlight-success > rect {
             fill: green !important;
             fill-opacity: 15% !important;
             stroke: green;
         }
-        .bpmn-activity-error > rect {
+        .bpmn-type-activity.highlight-error > rect {
             fill: red !important;
             fill-opacity: 20% !important;
             stroke: red;
         }
-
-        .bpmn-gateway-warning > path:nth-child(1) {
+        .bpmn-type-activity.highlight-in-progress > rect {
+            fill: var(--color-highlight) !important;
+            fill-opacity: 40% !important;
+        }
+        .bpmn-type-gateway.highlight-warning > path:nth-child(1) {
             fill: yellow !important;
             fill-opacity: 30% !important;
             stroke: orange;
@@ -64,26 +67,22 @@ limitations under the License.
         }
 
         /* edge arrow */
-        .bpmn-edge-path-highlight > path:nth-child(3) {
+        .bpmn-sequence-flow.highlight-path > path:nth-child(3) {
             fill: var(--color-highlight);
         }
         /* edge arrow */
-        .bpmn-edge-path-highlight > path:nth-child(3),
+        .bpmn-sequence-flow.highlight-path > path:nth-child(3),
         /* edge line */
-        .bpmn-edge-path-highlight > path:nth-child(2),
+        .bpmn-sequence-flow.highlight-path > path:nth-child(2),
         /* activity */
-        .bpmn-shape-path-highlight > rect,
+        .bpmn-type-activity.highlight-path > rect,
         /* gateway */
-        .bpmn-shape-path-highlight > path:nth-child(1),
+        .bpmn-type-gateway.highlight-path > path:nth-child(1),
         /* event */
-        .bpmn-shape-path-highlight > ellipse {
-            filter: blur(1.5px); /* only work on Firefox */
+        .bpmn-type-event.highlight-path > ellipse {
+            filter: blur(1.5px); /* may not work on Safari */
             stroke: var(--color-highlight);
             stroke-width: 7px;
-        }
-        .bpmn-activity-in-progress > rect {
-            fill: var(--color-highlight) !important;
-            fill-opacity: 40% !important;
         }
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>

--- a/examples/custom-behavior/apply-css-classes/index.js
+++ b/examples/custom-behavior/apply-css-classes/index.js
@@ -42,18 +42,18 @@ document.getElementById('btn-clear').onclick = function() {
 };
 
 document.getElementById('btn-info').onclick = function() {
-  toggleCssClass(['assignApprover', 'prepareBankTransfer'], 'bpmn-activity-info');
+  toggleCssClass(['assignApprover', 'prepareBankTransfer'], 'highlight-info');
 };
 document.getElementById('btn-success').onclick = function() {
-  addCssClass(['approveInvoice'], 'bpmn-activity-success');
+  addCssClass(['approveInvoice'], 'highlight-success');
   this.disabled = true;
 };
 document.getElementById('btn-warning').onclick = function() {
-  removeCssClass(['reviewSuccessful_gw', 'invoice_approved'], 'bpmn-gateway-warning');
+  removeCssClass(['reviewSuccessful_gw', 'invoice_approved'], 'highlight-warning');
   this.disabled = true;
 };
 document.getElementById('btn-error').onclick = function() {
-  addCssClass(['reviewInvoice'], 'bpmn-activity-error');
+  addCssClass(['reviewInvoice'], 'highlight-error');
   this.disabled = true;
 };
 
@@ -85,8 +85,8 @@ function pathHighLightingByGroup() {
       pathGroupStep = 'step1';
       break;
     case 'step1':
-      addHighlightPath(pathShapeElements, true);
-      addCssClass([pathLastShape], 'bpmn-activity-in-progress');
+      addHighlightPath(pathShapeElements);
+      addCssClass([pathLastShape], 'highlight-in-progress');
       pathGroupStep = 'step2';
       break;
     case 'step2':
@@ -94,14 +94,14 @@ function pathHighLightingByGroup() {
       pathGroupStep = 'step3';
       break;
     case 'step3':
-      removeHighlightPath(pathShapeElements, true);
-      removeCssClass([pathLastShape], 'bpmn-activity-in-progress');
+      removeHighlightPath(pathShapeElements);
+      removeCssClass([pathLastShape], 'highlight-in-progress');
       pathGroupStep = 'step4';
       break;
     case 'step4':
       addHighlightPath(pathEdgeElements);
-      addHighlightPath(pathShapeElements, true);
-      addCssClass([pathLastShape], 'bpmn-activity-in-progress');
+      addHighlightPath(pathShapeElements);
+      addCssClass([pathLastShape], 'highlight-in-progress');
       pathGroupStep = 'step5';
       break;
     default:
@@ -117,36 +117,36 @@ function pathHighLightingStepByStep() {
   }
 
   const pathElement = orderedPathElements[pathEltCount];
-  addHighlightPath(pathElement.name, pathElement.type === 'shape');
+  addHighlightPath(pathElement.name);
   pathEltCount++;
   // last element
   if (pathEltCount >= orderedPathElements.length) {
-    addCssClass([pathElement.name], 'bpmn-activity-in-progress');
+    addCssClass([pathElement.name], 'highlight-in-progress');
   }
 }
 
 function applyInitialStyles() {
-  addCssClass(['assignApprover'], 'bpmn-activity-info');
-  addCssClass(['reviewSuccessful_gw', 'invoice_approved'], 'bpmn-gateway-warning');
+  addCssClass(['assignApprover'], 'highlight-info');
+  addCssClass(['reviewSuccessful_gw', 'invoice_approved'], 'highlight-warning');
 }
 
 function clearAllStyles() {
-  removeCssClass(styledElements, 'bpmn-activity-info', 'bpmn-activity-success', 'bpmn-activity-error', 'bpmn-gateway-warning')
+  removeCssClass(styledElements, 'highlight-info', 'highlight-success', 'highlight-error', 'highlight-warning')
   clearHighlightPath();
 }
 
 
-function addHighlightPath(elements, isShape) {
-  addCssClass(elements, getPathHighlightClassName(isShape));
+function addHighlightPath(elements) {
+  addCssClass(elements, getPathHighlightClassName());
 }
-function getPathHighlightClassName(isShape) {
-  return isShape ? 'bpmn-shape-path-highlight' : 'bpmn-edge-path-highlight';
+function getPathHighlightClassName() {
+  return 'highlight-path';
 }
-function removeHighlightPath(elements, isShape) {
-  removeCssClass(elements, getPathHighlightClassName(isShape));
+function removeHighlightPath(elements) {
+  removeCssClass(elements, getPathHighlightClassName());
 }
 function clearHighlightPath() {
-  removeCssClass(pathEdgeElements.concat(pathShapeElements), 'bpmn-edge-path-highlight', 'bpmn-shape-path-highlight', 'bpmn-activity-in-progress');
+  removeCssClass(pathEdgeElements.concat(pathShapeElements), getPathHighlightClassName(), 'highlight-in-progress');
   pathGroupStep = 'none';
   pathEltCount = 0;
 }


### PR DESCRIPTION
Do not define specific class names for shape and edge or for dedicated BPMN kinds.
Instead, define generic class names and use selectors involving the `bpmn-xxx` classes already existing on elements.

closes #268

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/268-simplify_css_definitions/examples/index.html