### PR TITLE
[INFRA] Fix the script that update the lib version

### DIFF
--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -20,7 +20,7 @@ function replaceVersion() {
     fi
   else
     if [[ $directory == *demo ]]; then
-      sed -i -E "${rexep_others}#" **/*.{html,md,js}
+      sed -i -E "${rexep_others}#" **/*.{html,md}
     elif [[ $directory == *projects ]]; then
       sed -i -E "${rexep_npm}#" **/package.json
     else


### PR DESCRIPTION
There is no js file to update in the 'demo' folder. The previous implementation failed because it required a js file to
be present in the folder. it is no longer necessary.

The former error was `sed: can't read **/*.js: No such file or directory`.