### PR TITLE
[INFRA] Bump devDependencies in the "Vitejs" project

### DIFF
--- a/projects/typescript-vanilla-with-vitejs/README.md
+++ b/projects/typescript-vanilla-with-vitejs/README.md
@@ -6,7 +6,7 @@ To run locally:
 
 1. `npm install`
 2. `npm start`
-3. [localhost app](http://localhost:3000)
+3. [localhost app](http://localhost:5173)
 
 You will see the following diagram:
 
@@ -15,4 +15,4 @@ You will see the following diagram:
 The code calling `bpmn-visualization` to render the BPMN diagram is available in [main.ts](src/main.ts).
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
-bundle application.
+bundle application with http://localhost:4173.

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -12,7 +12,7 @@
     "bpmn-visualization": "0.25.0"
   },
   "devDependencies": {
-    "typescript": "~4.6.4",
-    "vite": "~2.9.9"
+    "typescript": "~4.7.4",
+    "vite": "~3.0.0-beta.6"
   }
 }


### PR DESCRIPTION
typescript from 4.6.4 to 4.7.4
vite from 2.9.9 to 3.0.0-beta.6