### PR TITLE
[FEAT] Allow remote loading of the new miwg-test-suite BPMN files

### DIFF
--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
@@ -94,7 +94,7 @@ const miwgFileNames = [
   'A.4.0', 'A.4.1',
   'B.1.0', 'B.2.0',
   'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
-  'C.5.0', 'C.6.0', 'C.7.0',
+  'C.5.0', 'C.6.0', 'C.7.0', 'C.8.0', 'C.8.1',
   // extra file to get fetch error
   'do-not-exist',
   // extra file to get load error


### PR DESCRIPTION
C.8.0 and C.8.1 files have been available since April 2022 (https://github.com/bpmn-miwg/bpmn-miwg-test-suite/commit/3f6b99df1c3de4915aca7454daa0a0df5fd4060a) but were missing in the example.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/load_more_miwg-test-suite_bpmn_files/examples/index.html
