### PR TITLE
[REFACTOR] Use object literal instead of static only class

### DIFF
--- a/examples/static/js/style-identifiers.js
+++ b/examples/static/js/style-identifiers.js
@@ -1,34 +1,28 @@
-/**
- * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
- */
-class StyleIdentifiers {
-    static STYLE_FILLCOLOR = 'fillColor';
-    static STYLE_STROKECOLOR = 'strokeColor';
+// Define substitutes for mxGraph mxConstants as they are not available here.
+// Use the same property names as in mxConstants for easy substitution: see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
 
-    static STYLE_GRADIENT_DIRECTION = 'gradientDirection';
-    static STYLE_GRADIENTCOLOR = 'gradientColor';
+const StyleIdentifiers = {
+  STYLE_FILLCOLOR: 'fillColor',
+  STYLE_STROKECOLOR: 'strokeColor',
 
-    static STYLE_FONTCOLOR = 'fontColor';
-    static STYLE_FONTFAMILY = 'fontFamily';
-    static STYLE_FONTSIZE = 'fontSize';
-    static STYLE_FONTSTYLE = 'fontStyle';
+  STYLE_GRADIENT_DIRECTION: 'gradientDirection',
+  STYLE_GRADIENTCOLOR: 'gradientColor',
 
-    static STYLE_SWIMLANE_FILLCOLOR = 'swimlaneFillColor';
+  STYLE_FONTCOLOR: 'fontColor',
+  STYLE_FONTFAMILY: 'fontFamily',
+  STYLE_FONTSIZE: 'fontSize',
+  STYLE_FONTSTYLE: 'fontStyle',
+
+  STYLE_SWIMLANE_FILLCOLOR: 'swimlaneFillColor',
 }
 
-/**
- * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
- */
-class Directions {
-    static DIRECTION_EAST = 'east';
-    static DIRECTION_SOUTH = 'south';
-    static DIRECTION_WEST = 'west';
+const Directions = {
+  DIRECTION_EAST: 'east',
+  DIRECTION_SOUTH: 'south',
+  DIRECTION_WEST: 'west',
 }
 
-/**
- * Substitute mxGraph mxConstants, see https://jgraph.github.io/mxgraph/docs/js-api/files/util/mxConstants-js.html#mxConstants
- */
-class FontStyle {
-    static FONT_BOLD = 1;
-    static FONT_ITALIC = 2;
+const FontStyle = {
+  FONT_BOLD: 1,
+  FONT_ITALIC: 2,
 }


### PR DESCRIPTION
Apply it to `mxConstants` substitutes.

Rationale: see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/refactor/use_object_literal_instead_of_static_only_class/examples/index.html
