### PR TITLE
[INFRA] Update devDependencies in projects

### DIFF
--- a/projects/javascript-vanilla-with-webpack/.npmrc
+++ b/projects/javascript-vanilla-with-webpack/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "html-webpack-plugin": "~5.5.0",
-    "webpack": "~5.72.1",
-    "webpack-cli": "~4.9.2",
-    "webpack-dev-server": "~4.9.0"
+    "webpack": "~5.74.0",
+    "webpack-cli": "~4.10.0",
+    "webpack-dev-server": "~4.10.0"
   }
 }

--- a/projects/typescript-vanilla-with-parcel/.npmrc
+++ b/projects/typescript-vanilla-with-parcel/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/projects/typescript-vanilla-with-rollup/.npmrc
+++ b/projects/typescript-vanilla-with-rollup/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,16 +13,16 @@
     "bpmn-visualization": "0.25.2"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~22.0.0",
+    "@rollup/plugin-commonjs": "~22.0.2",
     "@rollup/plugin-node-resolve": "~13.3.0",
     "rimraf": "~3.0.2",
-    "rollup": "~2.73.0",
+    "rollup": "~2.77.3",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",
-    "rollup-plugin-serve": "~1.1.0",
+    "rollup-plugin-serve": "~2.0.0",
     "rollup-plugin-string": "~3.0.0",
     "rollup-plugin-typescript2": "~0.31.2",
-    "typescript": "~4.6.4"
+    "typescript": "~4.7.4"
   }
 }

--- a/projects/typescript-vanilla-with-vitejs/.npmrc
+++ b/projects/typescript-vanilla-with-vitejs/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "~4.7.4",
-    "vite": "~3.0.0-beta.6"
+    "vite": "~3.0.5"
   }
 }


### PR DESCRIPTION
Apply to all projects except Parcel TS as dependencies were already up-to-date.

In addition, configure npm to not generate package-lock. We don't commit lock files because we don't want to have to
update it when bumping the bpmn-visualization version. So it is not used for CI tasks. It was previously only generated
locally and generally not used by developers.

**Notes**

I have tested all dev and build commands locally.