### PR TITLE
[INFRA] Update release notes generation after label change

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,9 +2,9 @@
 changelog:
   exclude:
     labels:
-      - infra:build
-      - infra:repo
+      - chore
       - dependencies
+      - skip-changelog
   categories:
     - title: 🎉 New Features
       labels:


### PR DESCRIPTION
- remove `infra:build` and `infra:repo` that are replaced by `chore`
- add `skip-changelog` to explicitly ignore a Pull Request