### PR TITLE
[FEAT] Use the lowest possible version of TypeScript in projects

### DIFF
--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@parcel/transformer-inline-string": "~2.7.0",
     "parcel": "~2.7.0",
-    "typescript": "~4.5"
+    "typescript": "~4.5.5"
   },
   "alias": {
     "bpmn-visualization": "bpmn-visualization/dist/bpmn-visualization.esm.js"

--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@parcel/transformer-inline-string": "~2.7.0",
     "parcel": "~2.7.0",
-    "typescript": "~4.7.4"
+    "typescript": "~4.5"
   },
   "alias": {
     "bpmn-visualization": "bpmn-visualization/dist/bpmn-visualization.esm.js"

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.esm.js",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "rollup -c",
+    "build": "tsc && rollup -c",
     "start": "rollup -cw --environment devMode:true"
   },
   "dependencies": {
@@ -23,6 +23,6 @@
     "rollup-plugin-serve": "~2.0.0",
     "rollup-plugin-string": "~3.0.0",
     "rollup-plugin-typescript2": "~0.31.2",
-    "typescript": "~4.7.4"
+    "typescript": "~4.5"
   }
 }

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -23,6 +23,6 @@
     "rollup-plugin-serve": "~2.0.0",
     "rollup-plugin-string": "~3.0.0",
     "rollup-plugin-typescript2": "~0.31.2",
-    "typescript": "~4.5"
+    "typescript": "~4.5.5"
   }
 }

--- a/projects/typescript-vanilla-with-rollup/tsconfig.json
+++ b/projects/typescript-vanilla-with-rollup/tsconfig.json
@@ -1,14 +1,18 @@
 {
   "compilerOptions": {
-    "declaration": false,
     "outDir": "./dist",
     "module": "es6",
     "target": "es6",
     "strict": true,
     "skipLibCheck": false,
     "moduleResolution": "node",
+    "noEmit": true, // tsc only used for checks, Rollup manages file generation
     "sourceMap": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules/@typed-mxgraph"
+    ],
   },
   "include": [
     "src/**/*"

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -12,7 +12,7 @@
     "bpmn-visualization": "0.26.1"
   },
   "devDependencies": {
-    "typescript": "~4.5",
+    "typescript": "~4.5.5",
     "vite": "~3.1.1"
   }
 }

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -12,7 +12,7 @@
     "bpmn-visualization": "0.26.1"
   },
   "devDependencies": {
-    "typescript": "~4.7.4",
-    "vite": "~3.0.5"
+    "typescript": "~4.5",
+    "vite": "~3.1.1"
   }
 }


### PR DESCRIPTION
Downgrade to TS 4.5 which is the lowest version that bpmn-visualization needs to work.

Ensure that the TS type checks run in the Rollup project.
Also bump Vite from 3.0.5 to 3.1.1

refs https://github.com/process-analytics/bpmn-visualization-js/issues/2246