### PR TITLE
[DOC] Explain webpack/parcel config for old versions

### DIFF
--- a/projects/javascript-vanilla-with-webpack/README.md
+++ b/projects/javascript-vanilla-with-webpack/README.md
@@ -16,15 +16,8 @@ The code calling `bpmn-visualization` to render the BPMN diagram is available in
 Any code changes is quickly made available in the browser.
 
 
-## WARNING about the webpack configuration
+## WARNING about the webpack configuration for old bpmn-visualization versions
 
-Make sure you have defined the `mainFields` in the configuration, otherwise, `bpmn-visualization` doesn't load correctly.
-In this project, this is configured in [webpack.config.js](./webpack.config.js).
+When using bpmn-visualization@0.26.1 or older, a special configuration is required.
 
-```json
-    resolve:{
-        mainFields: ['module', 'main'],
-    },
-```
-
-See the [webpack 'resolve main fields' documentation](https://webpack.js.org/configuration/resolve/#resolvemainfields) for more details.
+See the [README of the 0.26.1 examples](https://github.com/process-analytics/bpmn-visualization-examples/blob/v0.26.1/projects/javascript-vanilla-with-webpack/README.md) for more details.

--- a/projects/javascript-vanilla-with-webpack/README.md
+++ b/projects/javascript-vanilla-with-webpack/README.md
@@ -18,6 +18,6 @@ Any code changes is quickly made available in the browser.
 
 ## WARNING about the webpack configuration for old bpmn-visualization versions
 
-When using bpmn-visualization@0.26.1 or older, a special configuration is required.
+When using bpmn-visualization@0.26.1 or older, a special configuration is required. This no more needed starting from version 0.26.2 (see [PR 384 ](https://github.com/process-analytics/bpmn-visualization-examples/pull/384) for more explanations).
 
-See the [README of the 0.26.1 examples](https://github.com/process-analytics/bpmn-visualization-examples/blob/v0.26.1/projects/javascript-vanilla-with-webpack/README.md) for more details.
+To know how to configure Webpack for such versions, see the [README of the 0.26.1 examples](https://github.com/process-analytics/bpmn-visualization-examples/blob/v0.26.1/projects/javascript-vanilla-with-webpack/README.md) for more details.

--- a/projects/javascript-vanilla-with-webpack/README.md
+++ b/projects/javascript-vanilla-with-webpack/README.md
@@ -1,4 +1,4 @@
-# Integrate `bpmn-visualization` in a vanilla webpack JavaScript project
+# Integrate `bpmn-visualization` in a vanilla Webpack JavaScript project
 
 ## Usage
 
@@ -16,7 +16,7 @@ The code calling `bpmn-visualization` to render the BPMN diagram is available in
 Any code changes is quickly made available in the browser.
 
 
-## WARNING about the webpack configuration for old bpmn-visualization versions
+## WARNING about the Webpack configuration for old bpmn-visualization versions
 
 When using bpmn-visualization@0.26.1 or older, a special configuration is required. This no more needed starting from version 0.26.2 (see [PR 384 ](https://github.com/process-analytics/bpmn-visualization-examples/pull/384) for more explanations).
 

--- a/projects/typescript-vanilla-with-parcel/README.md
+++ b/projects/typescript-vanilla-with-parcel/README.md
@@ -15,3 +15,10 @@ You will see the following diagram:
 The code calling `bpmn-visualization` to render the BPMN diagram is available in [index.ts](src/index.ts).
 
 If you want to bundle the application, run `npm run build`.
+
+
+## WARNING about the Parcel configuration for old bpmn-visualization versions
+
+When using bpmn-visualization@0.26.1 or older, a special configuration is required. This no more needed starting from version 0.26.2 (see [PR 384 ](https://github.com/process-analytics/bpmn-visualization-examples/pull/384) for more explanations).
+
+For old versions, configure an alias in the package.json: https://github.com/process-analytics/bpmn-visualization-examples/blob/v0.26.1/projects/typescript-vanilla-with-parcel/package.json#L18-L20


### PR DESCRIPTION
Add a link to the documentation of previous versions to guide user that cannot use the latest bpmn-visualization version.