### PR TITLE
[FEAT] Add the new "2022" theme in the Hacktoberfest demo

### DIFF
--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -22,13 +22,15 @@ limitations under the License.
     <link rel="stylesheet" href="../../examples/static/css/main.css" type="text/css">
     <link rel="stylesheet" href="../static/css/style.css" type="text/css">
     <style>
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&display=swap');
+
         .hacktoberfest-2022 {
             font-family: 'JetBrains Mono', monospace;
         }
+
         /* extend existing style */
         .bpmn-container {
-            background-color:inherit;
+            background-color: inherit;
         }
     </style>
     <script defer src="../../examples/static/js/link-to-sources.js"></script>

--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -23,6 +23,13 @@ limitations under the License.
     <link rel="stylesheet" href="../static/css/style.css" type="text/css">
     <style>
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&display=swap');
+        .hacktoberfest-2022 {
+            font-family: 'JetBrains Mono', monospace;
+        }
+        /* extend existing style */
+        .bpmn-container {
+            background-color:inherit;
+        }
     </style>
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
@@ -113,21 +120,22 @@ limitations under the License.
             <div id="use-case-panel" class="column bg-gray">
                 <div class="column col-12 text-center">
                     <h4 id="2020-light-title" class="d-hide">Light Hacktoberfest 2020 Theme</h4>
-                    <h4 id="2020-dark-title">Dark Hacktoberfest 2020 Theme</h4>
+                    <h4 id="2020-dark-title" class="d-hide">Dark Hacktoberfest 2020 Theme</h4>
                     <h4 id="2021-light-title" class="d-hide">Light Hacktoberfest 2021 Theme</h4>
-                    <h4 id="2021-dark-title">Dark Hacktoberfest 2021 Theme</h4>
-                    <h4 id="2022-light-title" class="d-hide" style="font-family: 'JetBrains Mono', monospace;">Light Hacktoberfest 2022 Theme</h4>
-                    <h4 id="2022-dark-title" style="font-family: 'JetBrains Mono', monospace;">Dark Hacktoberfest 2022 Theme</h4>
+                    <h4 id="2021-dark-title" class="d-hide">Dark Hacktoberfest 2021 Theme</h4>
+                    <h4 id="2022-light-title" class="hacktoberfest-2022 d-hide">Light Hacktoberfest 2022 Theme</h4>
+                    <h4 id="2022-dark-title" class="hacktoberfest-2022 d-hide">Dark Hacktoberfest 2022 Theme</h4>
                     <h4 id="default-title" class="d-hide">Default Theme</h4>
                 </div>
                 <div class="column col-12">
-                    <div id="2020-light-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
-                    <div id="2020-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
-                    <div id="2021-light-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
-                    <div id="2021-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
-                    <div id="2022-light-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
-                    <div id="2022-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
-                    <div id="default-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
+                    <div id="2020-light-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <div id="2020-dark-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <div id="2021-light-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <div id="2021-dark-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <div id="2022-light-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <div id="2022-dark-bpmn-container" class="column col-12 bpmn-container d-hide"></div>
+                    <!-- Only display a single container while loading. -->
+                    <div id="default-bpmn-container" class="column col-12 bpmn-container"></div>
                 </div>
             </div>
         </div>

--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -21,6 +21,9 @@ limitations under the License.
     <link rel="stylesheet" href="../../examples/static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../examples/static/css/main.css" type="text/css">
     <link rel="stylesheet" href="../static/css/style.css" type="text/css">
+    <style>
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&display=swap');
+    </style>
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.26.2/dist/bpmn-visualization.min.js"></script>
@@ -75,7 +78,7 @@ limitations under the License.
                     <div class="column col-4">
                         <div>
                             <h5>Project name</h5>
-                            <input id="project-name-input" type="text" value="BPMN Visualization">
+                            <input id="project-name-input" type="text" value="bpmn-visualization">
                         </div>
                     </div>
                     <div id="choose-use-case-panel" class="column col-4">
@@ -100,7 +103,8 @@ limitations under the License.
                         <div class="form-group">
                             <select id="theme-year-select" class="form-select">
                                 <option>2020</option>
-                                <option selected>2021</option>
+                                <option>2021</option>
+                                <option selected>2022</option>
                             </select>
                         </div>
                     </div>
@@ -112,6 +116,8 @@ limitations under the License.
                     <h4 id="2020-dark-title">Dark Hacktoberfest 2020 Theme</h4>
                     <h4 id="2021-light-title" class="d-hide">Light Hacktoberfest 2021 Theme</h4>
                     <h4 id="2021-dark-title">Dark Hacktoberfest 2021 Theme</h4>
+                    <h4 id="2022-light-title" class="d-hide" style="font-family: 'JetBrains Mono', monospace;">Light Hacktoberfest 2022 Theme</h4>
+                    <h4 id="2022-dark-title" style="font-family: 'JetBrains Mono', monospace;">Dark Hacktoberfest 2022 Theme</h4>
                     <h4 id="default-title" class="d-hide">Default Theme</h4>
                 </div>
                 <div class="column col-12">
@@ -119,6 +125,8 @@ limitations under the License.
                     <div id="2020-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
                     <div id="2021-light-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
                     <div id="2021-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
+                    <div id="2022-light-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
+                    <div id="2022-dark-bpmn-container" class="column col-12 bpmn-container" style="background-color:inherit"></div>
                     <div id="default-bpmn-container" class="column col-12 bpmn-container d-hide" style="background-color:inherit"></div>
                 </div>
             </div>

--- a/demo/hacktoberfest-custom-themes/js/theme-bpmn-visualization.js
+++ b/demo/hacktoberfest-custom-themes/js/theme-bpmn-visualization.js
@@ -11,52 +11,45 @@ class ThemeBpmnVisualization extends bpmnvisu.BpmnVisualization {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
 
         // START EVENT
-        let style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_START];
-        style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.startEvent.stroke;
-        if (this._theme.startEvent.fill) {
-            style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.startEvent.fill;
-        }
+        configureStyle(styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_START], this._theme.startEvent);
 
         // END EVENT
-        style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_END];
-        style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.endEvent.stroke;
-        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.endEvent.fill;
-        if (this._theme.endEvent.gradient) {
-            style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = Directions.DIRECTION_WEST;
-            style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = this._theme.endEvent.gradient;
-        }
+        configureStyle(styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.EVENT_END], this._theme.endEvent);
 
         // USER TASK
-        style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.TASK_USER];
-        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.userTask.fill;
-        if (this._theme.userTask.font) {
-            style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.userTask.font;
-        }
+        configureStyle(styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.TASK_USER], this._theme.userTask);
 
         // EXCLUSIVE GATEWAY
-        if (this._theme.exclusiveGateway.fill) {
-            style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.GATEWAY_EXCLUSIVE];
-            style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.exclusiveGateway.fill;
-        }
+        configureStyle(styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.GATEWAY_EXCLUSIVE], this._theme.exclusiveGateway);
 
         // CALL ACTIVITY
-        style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.CALL_ACTIVITY];
-        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.callActivity.fill;
-        style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.callActivity.font;
-        if (this._theme.callActivity.stroke) {
-            style[StyleIdentifiers.STYLE_STROKECOLOR] = this._theme.callActivity.stroke;
-        }
+        configureStyle(styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.CALL_ACTIVITY], this._theme.callActivity);
 
         // POOL
-        style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.POOL];
-        style[StyleIdentifiers.STYLE_FILLCOLOR] = this._theme.pool.labelFill;
-        style[StyleIdentifiers.STYLE_SWIMLANE_FILLCOLOR] = this._theme.pool.swimlaneFill;
-        style[StyleIdentifiers.STYLE_FONTSIZE] = 16;
-        if (this._theme.pool.font) {
-            style[StyleIdentifiers.STYLE_FONTCOLOR] = this._theme.pool.font;
-        }
+        const style = styleSheet.styles[bpmnvisu.ShapeBpmnElementKind.POOL];
+        const themePool = this._theme.pool;
+        configureStyle(style, themePool);
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = themePool.labelFill;
+        style[StyleIdentifiers.STYLE_SWIMLANE_FILLCOLOR] = themePool.swimlaneFill;
+        style[StyleIdentifiers.STYLE_FONTSIZE] = themePool.fontSize ?? 16;
     }
 
+}
+
+function configureStyle(style, themeElement) {
+    if (themeElement.fill) {
+        style[StyleIdentifiers.STYLE_FILLCOLOR] = themeElement.fill;
+    }
+    if (themeElement.font) {
+        style[StyleIdentifiers.STYLE_FONTCOLOR] = themeElement.font;
+    }
+    if (themeElement.gradient) {
+        style[StyleIdentifiers.STYLE_GRADIENT_DIRECTION] = themeElement.gradientDirection ?? Directions.DIRECTION_WEST;
+        style[StyleIdentifiers.STYLE_GRADIENTCOLOR] = themeElement.gradient;
+    }
+    if (themeElement.stroke) {
+        style[StyleIdentifiers.STYLE_STROKECOLOR] = themeElement.stroke;
+    }
 }
 
 class ThemeIconPainter extends bpmnvisu.IconPainter {

--- a/demo/hacktoberfest-custom-themes/js/theme.js
+++ b/demo/hacktoberfest-custom-themes/js/theme.js
@@ -191,7 +191,7 @@ themes.set("2021",
 themes.set("2022", new Map([
     ['dark', {
         default: {
-            // TODO when disabling this, the gradient of the gateway doesn't work anymore
+            // keep this to make the gateway gradient work
             fill: colors2022.primaryVoid,
             stroke: colors2022.primaryManga,
             font: colors2022.primaryManga,
@@ -224,11 +224,8 @@ themes.set("2022", new Map([
             icon: colors2022.primaryManga
         },
         pool: {
-            // labelFill: 'rgba(23, 15, 30, 0.5)',
             labelFill: colors2022.primaryVoid,
-            // TODO find a way to have gradient (introduce a fake bpmn lane if no other solution is possible)
             swimlaneFill: colors2022.primaryVoid,
-            // font: colors2021.brownLight
             fontSize: fonts2022.poolFontSize,
         }
     }],

--- a/demo/hacktoberfest-custom-themes/js/theme.js
+++ b/demo/hacktoberfest-custom-themes/js/theme.js
@@ -25,6 +25,28 @@ const colors2021 = {
     orangeDark: '#B53A25',
 };
 
+// Colors are taken from the Figma official design (https://do.co/hacktoberbrand)
+const colors2022 = {
+    // Primary colors (background and font)
+    // Primary/Manga (kind of white)
+    primaryManga:'#E5E1E6',
+    // Primary/Void (kind of black)
+    primaryVoid: '#170F1E',
+
+    // Secondary colors (in the Hacktoberfest logo)
+    // Secondary/Spark (kind of yellow)
+    secondarySpark: '#FFE27D',
+    // Secondary/Surf (kind of green)
+    secondarySurf: '#64E3FF',
+    // Secondary/Psybeam (kind of purple)
+    secondaryPsybeam: '#9092FF',
+};
+const fonts2022= {
+    family: 'JetBrains Mono, monospace',
+    size: 9,
+    poolFontSize: 14,
+}
+
 const themes = new Map();
 themes.set("2020",
     new Map([['dark', {
@@ -165,3 +187,93 @@ themes.set("2021",
         }
     }]]));
 
+
+themes.set("2022", new Map([
+    ['dark', {
+        default: {
+            // TODO when disabling this, the gradient of the gateway doesn't work anymore
+            fill: colors2022.primaryVoid,
+            stroke: colors2022.primaryManga,
+            font: colors2022.primaryManga,
+            fontFamily: fonts2022.family,
+            fontSize: fonts2022.size,
+        },
+        startEvent: {
+            fill: colors2022.primaryManga,
+            gradient: colors2022.secondaryPsybeam,
+            gradientDirection: Directions.DIRECTION_WEST,
+            stroke: colors2022.secondaryPsybeam,
+            icon: colors2022.secondaryPsybeam
+        },
+        endEvent: {
+            fill: colors2022.primaryManga,
+            gradient: colors2022.secondarySurf,
+            gradientDirection: Directions.DIRECTION_EAST,
+            stroke: colors2022.secondaryPsybeam,
+        },
+        exclusiveGateway: {
+            fill: colors2022.secondaryManga,
+            gradient: colors2022.secondarySpark,
+            gradientDirection: Directions.DIRECTION_EAST,
+            insideIcon: colors2022.secondarySpark,
+        },
+        userTask: {
+            icon: colors2022.primaryManga
+        },
+        callActivity: {
+            icon: colors2022.primaryManga
+        },
+        pool: {
+            // labelFill: 'rgba(23, 15, 30, 0.5)',
+            labelFill: colors2022.primaryVoid,
+            // TODO find a way to have gradient (introduce a fake bpmn lane if no other solution is possible)
+            swimlaneFill: colors2022.primaryVoid,
+            // font: colors2021.brownLight
+            fontSize: fonts2022.poolFontSize,
+        }
+    }],
+    ['light', {
+        default: {
+            stroke: colors2022.primaryVoid,
+            font: colors2022.primaryVoid,
+            fontFamily: fonts2022.family,
+            fontSize: fonts2022.size,
+        },
+        startEvent: {
+            stroke: colors2022.primaryManga,
+            fill: colors2022.secondaryPsybeam,
+            gradient: colors2022.secondarySurf,
+            gradientDirection: Directions.DIRECTION_WEST,
+            icon: colors2022.primaryManga,
+        },
+        endEvent: {
+            fill: colors2022.secondaryPsybeam,
+            gradient: colors2022.secondarySpark,
+            stroke: colors2022.secondaryPsybeam,
+        },
+        exclusiveGateway: {
+            fill: colors2022.secondarySpark,
+            gradient: colors2022.primaryManga,
+            gradientDirection: Directions.DIRECTION_EAST,
+            insideIcon: colors2022.primaryManga
+        },
+        userTask: {
+            fill: colors2022.secondarySurf,
+            gradient: colors2022.secondaryPsybeam,
+            gradientDirection: Directions.DIRECTION_EAST,
+            icon: colors2022.primaryVoid,
+        },
+        callActivity: {
+            fill: colors2022.primaryManga,
+            gradient: colors2022.secondarySurf,
+            gradientDirection: Directions.DIRECTION_WEST,
+            icon: colors2022.primaryVoid,
+        },
+        pool: {
+            labelFill: colors2022.secondaryPsybeam,
+            gradient: colors2022.secondarySurf,
+            gradientDirection: Directions.DIRECTION_NORTH,
+            fontSize: fonts2022.poolFontSize,
+        }
+    }]
+]));

--- a/demo/hacktoberfest-custom-themes/js/theme.js
+++ b/demo/hacktoberfest-custom-themes/js/theme.js
@@ -43,7 +43,7 @@ const colors2022 = {
 };
 const fonts2022= {
     family: 'JetBrains Mono, monospace',
-    size: 9,
+    size: 9.5,
     poolFontSize: 14,
 }
 

--- a/demo/hacktoberfest-custom-themes/js/use-case/theme-use-case.js
+++ b/demo/hacktoberfest-custom-themes/js/use-case/theme-use-case.js
@@ -5,6 +5,7 @@ class ThemeUseCase extends HacktoberfestUseCase {
     // Default BPMN Visualization theme
     #originalDefaultFontColor;
     #originalDefaultFontFamily;
+    #originalDefaultFontSize;
     #originalDefaultStrokeColor;
     #originalDefaultFillColor;
     #originalPoolLabelFillColor;
@@ -21,7 +22,8 @@ class ThemeUseCase extends HacktoberfestUseCase {
         bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR = this._theme.default.fill;
         bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR = this._theme.default.stroke;
         bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = this._theme.default.font;
-        bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = 'Inter, Helvetica, sans-serif';
+        bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = this._theme.default.fontFamily ?? 'Inter, Helvetica, sans-serif';
+        bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = this._theme.default.fontSize ?? bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE;
 
         const bpmnVisualization = this._internalBuildBpmnVisualization(options);
         this._restoreDefaultTheme();
@@ -34,6 +36,7 @@ class ThemeUseCase extends HacktoberfestUseCase {
     _saveDefaultTheme() {
         this.#originalDefaultFontColor = bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR;
         this.#originalDefaultFontFamily = bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY;
+        this.#originalDefaultFontSize = bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE;
         this.#originalDefaultStrokeColor = bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR;
         this.#originalDefaultFillColor = bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR;
         this.#originalPoolLabelFillColor = bpmnvisu.StyleDefault.POOL_LABEL_FILL_COLOR;
@@ -46,6 +49,7 @@ class ThemeUseCase extends HacktoberfestUseCase {
     _restoreDefaultTheme() {
         bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = this.#originalDefaultFontColor;
         bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = this.#originalDefaultFontFamily;
+        bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = this.#originalDefaultFontSize;
         bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR = this.#originalDefaultStrokeColor;
         bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR = this.#originalDefaultFillColor;
         bpmnvisu.StyleDefault.POOL_LABEL_FILL_COLOR = this.#originalPoolLabelFillColor;

--- a/examples/static/js/diagram/bpmn-diagrams.js
+++ b/examples/static/js/diagram/bpmn-diagrams.js
@@ -1677,7 +1677,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
       <bpmn:outgoing>sequence_flow_2</bpmn:outgoing>
       <bpmn:outgoing>sequence_flow_4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="user_task_1" name="Register on https://hacktoberfest.&#10;digitalocean.com">
+    <bpmn:userTask id="user_task_1" name="Register on https://hacktoberfest.com/">
       <bpmn:incoming>sequence_flow_2</bpmn:incoming>
       <bpmn:outgoing>sequence_flow_3</bpmn:outgoing>
     </bpmn:userTask>
@@ -1740,13 +1740,13 @@ function getHacktoberfestBpmnDiagram(projectName) {
       <bpmndi:BPMNEdge id="edge_sequence_flow_2" bpmnElement="sequence_flow_2">
         <di:waypoint x="400" y="185" />
         <di:waypoint x="400" y="119" />
-        <di:waypoint x="470" y="119" />
+        <di:waypoint x="450" y="119" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="372" y="150" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_sequence_flow_3" bpmnElement="sequence_flow_3">
-        <di:waypoint x="590" y="119" />
+        <di:waypoint x="600" y="119" />
         <di:waypoint x="660" y="119" />
         <di:waypoint x="660" y="185" />
       </bpmndi:BPMNEdge>
@@ -1806,7 +1806,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape_user_task_1" bpmnElement="user_task_1">
-        <dc:Bounds x="470" y="84" width="120" height="70" />
+        <dc:Bounds x="450" y="84" width="150" height="70" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape_exclusive_gateway_2" bpmnElement="exclusive_gateway_2" isMarkerVisible="true">
         <dc:Bounds x="635" y="185" width="50" height="50" />
@@ -1814,7 +1814,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
       <bpmndi:BPMNShape id="shape_user_task_2" bpmnElement="user_task_2">
         <dc:Bounds x="785" y="170" width="130" height="70" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="795" y="195" width="110" height="45" />
+          <dc:Bounds x="792" y="193" width="113" height="45" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape_call_activity" bpmnElement="call_activity">
@@ -1997,7 +1997,7 @@ function getGettingStartedBpmnDiagram() {
     <bpmn:startEvent id="StartEvent_08hc3xj" name="Start coding">
       <bpmn:outgoing>Flow_1wkfbb0</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:task id="Activity_1potg3p" name="Enjoy using &#39;BPMN Visualization&#39;">
+    <bpmn:task id="Activity_1potg3p" name="Enjoy using &#39;bpmn-visualization&#39;">
       <bpmn:incoming>Flow_1wkfbb0</bpmn:incoming>
       <bpmn:outgoing>Flow_133a5kz</bpmn:outgoing>
     </bpmn:task>

--- a/examples/static/js/diagram/bpmn-diagrams.js
+++ b/examples/static/js/diagram/bpmn-diagrams.js
@@ -1672,7 +1672,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
       <bpmn:outgoing>sequence_flow_1</bpmn:outgoing>
       <bpmn:timerEventDefinition />
     </bpmn:startEvent>
-    <bpmn:exclusiveGateway id="exclusive_gateway_1" name="Already registered on Hacktoberfest website ?" default="sequence_flow_2">
+    <bpmn:exclusiveGateway id="exclusive_gateway_1" name="Already registered on the Hacktoberfest website?" default="sequence_flow_2">
       <bpmn:incoming>sequence_flow_1</bpmn:incoming>
       <bpmn:outgoing>sequence_flow_2</bpmn:outgoing>
       <bpmn:outgoing>sequence_flow_4</bpmn:outgoing>
@@ -1746,7 +1746,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_sequence_flow_3" bpmnElement="sequence_flow_3">
-        <di:waypoint x="600" y="119" />
+        <di:waypoint x="620" y="119" />
         <di:waypoint x="660" y="119" />
         <di:waypoint x="660" y="185" />
       </bpmndi:BPMNEdge>
@@ -1806,7 +1806,7 @@ function getHacktoberfestBpmnDiagram(projectName) {
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape_user_task_1" bpmnElement="user_task_1">
-        <dc:Bounds x="450" y="84" width="150" height="70" />
+        <dc:Bounds x="450" y="84" width="170" height="70" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape_exclusive_gateway_2" bpmnElement="exclusive_gateway_2" isMarkerVisible="true">
         <dc:Bounds x="635" y="185" width="50" height="50" />

--- a/examples/static/js/style-identifiers.js
+++ b/examples/static/js/style-identifiers.js
@@ -18,6 +18,7 @@ const StyleIdentifiers = {
 
 const Directions = {
   DIRECTION_EAST: 'east',
+  DIRECTION_NORTH: 'north',
   DIRECTION_SOUTH: 'south',
   DIRECTION_WEST: 'west',
 }


### PR DESCRIPTION
For the 1st time, use a dedicated font to better match the brand guidelines.

Improve the label bounds in the BPMN diagram, especially for the Hacktoberfest 2022 theme. Use the right wording for the lib name: "BPMN Visualization" --> "bpmn-visualization"

General improvements in theme management
  - let configure the default font size
  - remove duplication when applying the mxgraph styles and better manage default values
  - improve the page styles
    - display nothing prior the page is fully loaded. Previously several titles were displayed while loading.
    - do not duplicate styles and use CSS class instead of inline styles


covers #374

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/d5326c1/demo/hacktoberfest-custom-themes/index.html


<!--

Use the latest available commit

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/<BRANCH_NAME>/examples/index.html

-->

### Remaining Tasks

- [x] Review colors and gradients
- [x] Clean remaining comments and TODO




### Initial theme proposed in commit b4bd015

dark | light
----- | -----
![hacktoberfest_dark_theme_v02](https://user-images.githubusercontent.com/27200110/191526024-99f6954c-3a96-44e8-9f3d-a15153fd735d.png) | ![hacktoberfest_light_theme_v02](https://user-images.githubusercontent.com/27200110/191526038-3275c0f9-1ccb-462e-add8-d215327b9be2.png)


