### PR TITLE
[BUG] Remove unnecessary scripts from `html` page of `getting-started` tutorial

### DIFF
--- a/tutorials/getting-started/index.html
+++ b/tutorials/getting-started/index.html
@@ -21,11 +21,6 @@ limitations under the License.
     <link rel="stylesheet" href="../../examples/static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../examples/static/css/main.css" type="text/css">
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
-    <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.27.0/dist/bpmn-visualization.min.js"></script>
-    <!-- if you prefer unpkg, comment the previous line and uncomment the following line -->
-    <!--<script defer src="https://unpkg.com/browse/bpmn-visualization@0.27.0/dist//bpmn-visualization.min.js"></script>-->
-    <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
 </head>
 <body>
 <header class="navbar bg-dark p-2">


### PR DESCRIPTION
**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/remove_unnecessary_script_from_new_tuto/examples/index.html
