### PR TITLE
[FIX] Update the page title of the ICPM 2022 Demo

### DIFF
--- a/demo/icpm-2022/index.html
+++ b/demo/icpm-2022/index.html
@@ -15,7 +15,7 @@ limitations under the License.
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>BPMN Visualization - Getting started</title>
+    <title>BPMN Visualization - ICPM 2022 Demo</title>
     <link rel="icon" type="image/svg+xml" href="../../examples/favicon.svg">
     <link rel="stylesheet" href="../../examples/static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../examples/static/css/icons.min.css" type="text/css">


### PR DESCRIPTION
The previous title was "Getting started", probably because the page was created from this tutorial.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix/icpm_demo_title/examples/index.html