### PR TITLE
[DOC] Revert Hacktoberfest hero image from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">
     <p align="center">
         <a href="https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html">
-            <img src="./examples/static/img/preview/demo/hacktoberfest-custom-themes.png" alt="examples overview">
+            <img src="examples_home.png" alt="examples overview">
         </a> 
     </p>
     <p align="center">


### PR DESCRIPTION
Hacktoberfest is finished, so use the regular image.

The Hacktoberfest image in the README was introduced in #407