### PR TITLE
[FEAT] Angular example: add zoom reset and notifications

### DIFF
--- a/projects/typescript-angular/package.json
+++ b/projects/typescript-angular/package.json
@@ -10,23 +10,23 @@
     "test": "ng test"
   },
   "dependencies": {
-    "@angular/animations": "^14.2.8",
-    "@angular/common": "^14.2.8",
-    "@angular/compiler": "^14.2.8",
-    "@angular/core": "^14.2.8",
-    "@angular/forms": "^14.2.8",
-    "@angular/platform-browser": "^14.2.8",
-    "@angular/platform-browser-dynamic": "^14.2.8",
-    "@angular/router": "^14.2.8",
+    "@angular/animations": "~14.2.9",
+    "@angular/common": "~14.2.9",
+    "@angular/compiler": "~14.2.9",
+    "@angular/core": "~14.2.9",
+    "@angular/forms": "~14.2.9",
+    "@angular/platform-browser": "~14.2.9",
+    "@angular/platform-browser-dynamic": "~14.2.9",
+    "@angular/router": "~14.2.9",
     "bpmn-visualization": "0.28.0",
     "rxjs": "~7.5.7",
-    "tslib": "^2.4.1",
+    "tslib": "~2.4.1",
     "zone.js": "~0.11.8"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^14.2.7",
-    "@angular/cli": "~14.2.7",
-    "@angular/compiler-cli": "^14.2.8",
+    "@angular-devkit/build-angular": "~14.2.8",
+    "@angular/cli": "~14.2.8",
+    "@angular/compiler-cli": "~14.2.9",
     "@types/jasmine": "~4.3.0",
     "jasmine-core": "~4.5.0",
     "karma": "~6.4.1",
@@ -34,6 +34,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
+    "type-fest": "~3.1.0",
     "typescript": "~4.8.4"
   }
 }

--- a/projects/typescript-angular/src/app/app.module.ts
+++ b/projects/typescript-angular/src/app/app.module.ts
@@ -4,12 +4,14 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { BpmnExamplesComponent } from './bpmn-examples/bpmn-examples.component';
 import { BpmnVisualizationComponent } from './bpmn-visualization/bpmn-visualization.component';
+import { NotificationZoneComponent } from "./bpmn-examples/notification-zone.component";
 
 @NgModule({
   declarations: [
     AppComponent,
     BpmnExamplesComponent,
     BpmnVisualizationComponent,
+    NotificationZoneComponent,
   ],
   imports: [BrowserModule],
   providers: [],

--- a/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.css
+++ b/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.css
@@ -7,7 +7,7 @@
 .bpmn-visualization-viewer {
   height: 50vh;
   width: 75vw;
-  margin-top: 3rem;
+  margin-top: .5rem;
 
   border-style: solid;
   border-color: #303742;
@@ -41,4 +41,17 @@
 
 .faded-container {
   opacity: 20%;
+}
+
+.controls {
+  align-self: stretch;
+  justify-content: start;
+}
+
+.notification {
+  flex-grow: 1;
+  height: 12vh;
+  /*from the .card CSS rule*/
+  margin-right: 8px;
+  margin-left: 8px;
 }

--- a/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.html
+++ b/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.html
@@ -25,6 +25,19 @@
     <div *ngIf="loading" class="loader-container">
        <div class="loader"></div>
     </div>
-    <app-bpmn-visualization [ngClass]="loading? 'faded-container': ''" [diagram]="bpmnDiagram" [fitType]="fitTypeValue"></app-bpmn-visualization>
+    <app-bpmn-visualization [ngClass]="loading? 'faded-container': ''"
+                            [diagram]="bpmnDiagram"
+                            [fitType]="fitTypeValue">
+    </app-bpmn-visualization>
   </div>
+
+  <div class="card-container controls">
+    <div>
+      <button class="card card-small" [ngClass]="!bpmnDiagram? 'disabled': ''" [disabled]="!bpmnDiagram" (click)="fitDiagram()">Reset zoom level</button>
+    </div>
+    <div class="notification">
+      <app-notification-zone></app-notification-zone>
+    </div>
+  </div>
+
 </div>

--- a/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.ts
+++ b/projects/typescript-angular/src/app/bpmn-examples/bpmn-examples.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { FitType } from 'bpmn-visualization';
 import { BpmnDiagramService } from '../services/bpmn-diagram.service';
+import { BpmnNavigationService } from "../services/bpmn-navigation.service";
+import { ActionStatus } from "../utils/types";
 
 @Component({
   selector: 'app-bpmn-examples',
@@ -15,7 +17,7 @@ export class BpmnExamplesComponent {
   FitType = FitType; // makes the enum available in the template
   fitTypeValue?: FitType;
 
-  constructor(private bpmnDiagramService: BpmnDiagramService) {}
+  constructor(private bpmnDiagramService: BpmnDiagramService, private bpmnNavigationService: BpmnNavigationService) {}
 
   loadDiagram(diagramIdx: number) {
     this.loading = true;
@@ -25,5 +27,9 @@ export class BpmnExamplesComponent {
         this.bpmnDiagram = diagram;
         this.loading = false;
       });
+  }
+
+  fitDiagram() {
+    this.bpmnNavigationService.requestDiagramFit();
   }
 }

--- a/projects/typescript-angular/src/app/bpmn-examples/notification-zone.component.ts
+++ b/projects/typescript-angular/src/app/bpmn-examples/notification-zone.component.ts
@@ -1,0 +1,40 @@
+import { Component, type ElementRef, ViewChild } from '@angular/core';
+import { ActionStatus } from "../utils/types";
+import { ActionsNotifierService } from "../services/actions-notifier.service";
+
+@Component({
+  selector: 'app-notification-zone',
+  template: '<textArea #notification readonly></textArea>',
+  styles: [
+    `
+      textArea {
+        resize: none;
+        width: 100%;
+        height: 95%;
+        /*from the .card CSS rule*/
+        border-radius: 4px;
+        border: 1px solid #eee;
+        background-color: #fafafa;
+      }
+    `
+  ],
+})
+export class NotificationZoneComponent {
+  @ViewChild('notification', { static: true })
+  private textAreaRef: ElementRef<HTMLTextAreaElement> | undefined;
+
+  constructor(private actionsNotifierService: ActionsNotifierService) {
+    this.actionsNotifierService.subscribe(value => this.updateTextArea(value));
+  }
+
+  private updateTextArea(actionStatus: ActionStatus) {
+    const messageParts = [`${actionStatus.type}`];
+    actionStatus.subType && messageParts.push(`(${actionStatus.subType})`);
+    messageParts.push(`#${actionStatus.id}: ${actionStatus.status}`);
+    actionStatus.duration != undefined && messageParts.push(`in ${actionStatus.duration}ms`);
+
+    let textArea = this.textAreaRef!.nativeElement;
+    textArea.value += messageParts.join('\u0020') + '\n';
+    textArea.scrollTop = textArea.scrollHeight;
+  }
+}

--- a/projects/typescript-angular/src/app/services/actions-notifier.service.spec.ts
+++ b/projects/typescript-angular/src/app/services/actions-notifier.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ActionsNotifierService } from './actions-notifier.service';
+
+describe('ActionsNotifierService', () => {
+  let service: ActionsNotifierService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ActionsNotifierService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/typescript-angular/src/app/services/actions-notifier.service.ts
+++ b/projects/typescript-angular/src/app/services/actions-notifier.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Subject } from "rxjs";
+import { ActionStatus } from "../utils/types";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ActionsNotifierService {
+
+  private subject = new Subject<ActionStatus>();
+  private currentRequest = this.subject.asObservable();
+
+  post(value: ActionStatus) {
+    this.subject.next(value);
+  }
+
+  subscribe(next: (value: ActionStatus) => void): void {
+    this.currentRequest.subscribe(next);
+  }
+}

--- a/projects/typescript-angular/src/app/services/bpmn-navigation.service.spec.ts
+++ b/projects/typescript-angular/src/app/services/bpmn-navigation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BpmnNavigationService } from './bpmn-navigation.service';
+
+describe('BpmnNavigationServiceService', () => {
+  let service: BpmnNavigationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BpmnNavigationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/typescript-angular/src/app/services/bpmn-navigation.service.ts
+++ b/projects/typescript-angular/src/app/services/bpmn-navigation.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Subject } from "rxjs";
+import { ActionType } from "../utils/types";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BpmnNavigationService {
+  private subject = new Subject<ActionType>();
+  private currentRequest = this.subject.asObservable();
+
+  requestDiagramFit() {
+    this.subject.next('fit');
+  }
+
+  subscribe(type: ActionType, actionable: () => void): void {
+    this.currentRequest.subscribe(actionType => {
+      actionType == type && actionable();
+    });
+  }
+}

--- a/projects/typescript-angular/src/app/utils/types.ts
+++ b/projects/typescript-angular/src/app/utils/types.ts
@@ -1,0 +1,25 @@
+import { SetRequired } from "type-fest";
+import { FitType } from "bpmn-visualization";
+
+export type ActionType = 'fetch' | 'fit' | 'load';
+
+interface GenericActionStatus<Type extends ActionType, SubType> {
+  type: Type;
+  subType?: SubType;
+  status: 'in-progress' | 'done';
+  id: number;
+  duration?: number;
+}
+
+type ActionStatusWithRequiredSubType<Type extends ActionType, SubType> = SetRequired<GenericActionStatus<Type, SubType>, 'subType'>;
+
+type FitActionStatus = ActionStatusWithRequiredSubType<'fit', FitType>;
+
+type LoadActionStatus = GenericActionStatus<'load', undefined>;
+
+type FetchActionStatus = ActionStatusWithRequiredSubType<'fetch', 'diagram'>;
+
+export type ActionStatus =
+  | FetchActionStatus
+  | FitActionStatus
+  | LoadActionStatus;

--- a/projects/typescript-angular/src/styles.css
+++ b/projects/typescript-angular/src/styles.css
@@ -90,10 +90,18 @@ svg.material-icons:not(:last-child) {
 .card-container .card:not(.highlight-card) {
   cursor: pointer;
 }
+.card-container .card:not(.highlight-card).disabled {
+  cursor: default;
+  color: #333333ad;
+}
 
 .card-container .card:not(.highlight-card):hover {
   transform: translateY(-3px);
   box-shadow: 0 4px 17px rgba(0, 0, 0, 0.35);
+}
+.card-container .card:not(.highlight-card):hover.disabled {
+  transform: unset;
+  box-shadow: unset;
 }
 
 .card-container .card:not(.highlight-card):hover .material-icons path {
@@ -110,7 +118,7 @@ svg.material-icons:not(:last-child) {
   position: relative;
 }
 
-.card.card.highlight-card span {
+.card.highlight-card span {
   margin-left: 60px;
 }
 


### PR DESCRIPTION
Add a 'reset zoom level' button that uses the last selected Fit options.

The notifications zone track all actions
  - simulated fetch diagram
  - load diagram
  - reset zoom level (fit)

Also bump all dependencies.

covers #409 

### Screenshots

https://user-images.githubusercontent.com/27200110/199914993-a1792b99-198d-41b8-90f9-f098022c8764.mp4

