### PR TITLE
[FIX] Avoid build errors on new parcel releases

### DIFF
--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,8 +11,9 @@
     "bpmn-visualization": "0.28.1"
   },
   "devDependencies": {
-    "@parcel/transformer-inline-string": "~2.8.0",
-    "parcel": "~2.8.0",
+    "@parcel/core": "~2.7.0",
+    "@parcel/transformer-inline-string": "~2.7.0",
+    "parcel": "~2.7.0",
     "typescript": "~4.5.5"
   }
 }

--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,9 +11,9 @@
     "bpmn-visualization": "0.28.1"
   },
   "devDependencies": {
-    "@parcel/core": "~2.7.0",
-    "@parcel/transformer-inline-string": "~2.7.0",
-    "parcel": "~2.7.0",
+    "@parcel/core": "~2.8.0",
+    "@parcel/transformer-inline-string": "~2.8.0",
+    "parcel": "~2.8.0",
     "typescript": "~4.5.5"
   }
 }


### PR DESCRIPTION
Add an explicit dependency to `@parcel/core` to use a fixed version. This allows to not rely on parcel peerDependencies declaration which uses minor auto update. The update to the new version always create errors because of parcel components using incompatible versions:
    `@parcel/workers: Expected constructor 2.7.0:BundleGraph to be registered with serializer to deserialize`

closes #366

### Tests

0b88bdbd0d9f928f5927d806fd919cab4084166a uses parcel 2.7.0 whereas a new 2.8.0 version has been released. Unlike #425 that wasn't using a specific version of `@parcel/core`, there is no build issue.



### Root cause

The parcel dependencies are all synchronized (they depend on fixed version of parcel components) but they declare peerDependencies to @parcel/core like in the following extract of the package-lock.json file (I enabled it for the tests). When a new minor release is available the @parcel/core version is bumped automatically and it generates the error.

```json
    "node_modules/@parcel/config-default": {
      "version": "2.7.0",
....
      "peerDependencies": {
        "@parcel/core": "^2.7.0"
      }
```