### PR TITLE
[INFRA] Bump dependencies in parcel, vite and webpack projects

### DIFF
--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "html-webpack-plugin": "~5.5.0",
-    "webpack": "~5.74.0",
-    "webpack-cli": "~4.10.0",
-    "webpack-dev-server": "~4.10.0"
+    "webpack": "~5.75.0",
+    "webpack-cli": "~5.0.1",
+    "webpack-dev-server": "~4.11.1"
   }
 }

--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,9 +11,9 @@
     "bpmn-visualization": "0.29.1"
   },
   "devDependencies": {
-    "@parcel/core": "~2.8.0",
-    "@parcel/transformer-inline-string": "~2.8.0",
-    "parcel": "~2.8.0",
+    "@parcel/core": "~2.8.2",
+    "@parcel/transformer-inline-string": "~2.8.2",
+    "parcel": "~2.8.2",
     "typescript": "~4.5.5"
   }
 }

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "~4.5.5",
-    "vite": "~3.1.1"
+    "vite": "~4.0.4"
   }
 }


### PR DESCRIPTION
parcel from 2.8.0 to 2.8.2
vite from 3.1.1 to 4.0.4
webpack: various changes

### Other information

The Angular v15 and Rollup v3 bumps  will be done later. The dependencies update is not straightforwards.