### PR TITLE
chore(deps): bump to rollup@3 in the Rollup TS project

### DIFF
--- a/projects/typescript-vanilla-with-rollup/.npmrc
+++ b/projects/typescript-vanilla-with-rollup/.npmrc
@@ -1,1 +1,3 @@
 package-lock=false
+# rollup dependencies
+legacy-peer-deps=true

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -17,7 +17,7 @@
     "@rollup/plugin-node-resolve": "~15.0.1",
     "@rollup/plugin-terser": "~0.3.0",
     "rimraf": "~3.0.2",
-    "rollup": "~3.10.0",
+    "rollup": "~3.9.1",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -16,6 +16,7 @@
     "@rollup/plugin-commonjs": "~24.0.0",
     "@rollup/plugin-node-resolve": "~15.0.1",
     "@rollup/plugin-terser": "~0.3.0",
+    "@rollup/plugin-typescript": "~11.0.0",
     "rimraf": "~3.0.2",
     "rollup": "~3.9.1",
     "rollup-plugin-copy": "~3.4.0",
@@ -23,7 +24,7 @@
     "rollup-plugin-livereload": "~2.0.5",
     "rollup-plugin-serve": "~2.0.2",
     "rollup-plugin-string": "~3.0.0",
-    "rollup-plugin-typescript2": "~0.34.1",
+    "tslib": "~2.5.0",
     "typescript": "~4.5.5"
   }
 }

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,12 +13,12 @@
     "bpmn-visualization": "0.31.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~24.0.0",
+    "@rollup/plugin-commonjs": "~24.0.1",
     "@rollup/plugin-node-resolve": "~15.0.1",
-    "@rollup/plugin-terser": "~0.3.0",
+    "@rollup/plugin-terser": "~0.4.0",
     "@rollup/plugin-typescript": "~11.0.0",
-    "rimraf": "~3.0.2",
-    "rollup": "~3.9.1",
+    "rimraf": "~4.1.2",
+    "rollup": "~3.17.2",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -1,8 +1,8 @@
 {
   "name": "bpmn-visualization-ts-rollup",
-  "version": "1.0.0",
+  "version": "0.0.0",
+  "private": true,
   "license": "Apache-2.0",
-  "main": "index.js",
   "module": "dist/index.esm.js",
   "scripts": {
     "clean": "rimraf dist",

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,16 +13,17 @@
     "bpmn-visualization": "0.31.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~22.0.2",
-    "@rollup/plugin-node-resolve": "~13.3.0",
+    "@rollup/plugin-commonjs": "~24.0.0",
+    "@rollup/plugin-node-resolve": "~15.0.1",
+    "@rollup/plugin-terser": "~0.3.0",
     "rimraf": "~3.0.2",
-    "rollup": "~2.77.3",
+    "rollup": "~3.10.0",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",
     "rollup-plugin-serve": "~2.0.0",
     "rollup-plugin-string": "~3.0.0",
-    "rollup-plugin-typescript2": "~0.31.2",
+    "rollup-plugin-typescript2": "~0.34.1",
     "typescript": "~4.5.5"
   }
 }

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -21,7 +21,7 @@
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",
-    "rollup-plugin-serve": "~2.0.0",
+    "rollup-plugin-serve": "~2.0.2",
     "rollup-plugin-string": "~3.0.0",
     "rollup-plugin-typescript2": "~0.34.1",
     "typescript": "~4.5.5"

--- a/projects/typescript-vanilla-with-rollup/rollup.config.js
+++ b/projects/typescript-vanilla-with-rollup/rollup.config.js
@@ -21,6 +21,7 @@ import copyWatch from "rollup-plugin-copy-watch";
 import typescript from "rollup-plugin-typescript2";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
 import { string } from "rollup-plugin-string";
 import pkg from "./package.json";
 
@@ -55,6 +56,8 @@ if (devMode) {
   plugins.push(serve({contentBase: "dist", port: 10001}));
   // Allow to livereload on any update
   plugins.push(livereload({watch: "dist", verbose: true}));
+} else {
+  plugins.push(terser({ecma: 2015}));
 }
 
 export default [

--- a/projects/typescript-vanilla-with-rollup/rollup.config.mjs
+++ b/projects/typescript-vanilla-with-rollup/rollup.config.mjs
@@ -18,7 +18,7 @@ import livereload from "rollup-plugin-livereload";
 import copy from "rollup-plugin-copy";
 import copyWatch from "rollup-plugin-copy-watch";
 
-import typescript from "rollup-plugin-typescript2";
+import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";

--- a/projects/typescript-vanilla-with-rollup/rollup.config.mjs
+++ b/projects/typescript-vanilla-with-rollup/rollup.config.mjs
@@ -23,7 +23,9 @@ import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import { string } from "rollup-plugin-string";
-import pkg from "./package.json";
+// generate warning when running with Node 16
+// (node:75278) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
+import pkg from './package.json' assert { type: 'json' };
 
 const devMode = process.env.devMode ?? false;
 

--- a/projects/typescript-vanilla-with-rollup/src/index.ts
+++ b/projects/typescript-vanilla-with-rollup/src/index.ts
@@ -26,7 +26,6 @@ const bpmnVisualization = new BpmnVisualization({
 bpmnVisualization.load(diagram);
 
 // display the bpmn-visualization version in the footer
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const footer = document.querySelector<HTMLElement>("footer")!;
 const version = bpmnVisualization.getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;


### PR DESCRIPTION
In addition, to the `rollup` library update:
  - Bump all dependencies to the latest available version. The typescript lib was kept untouched as we want to keep using an old version.
  - Switch from `rollup-plugin-typescript2` to `@rollup/plugin-typescript` to use the plugin provided by the rollup project.
  - Introduce the terser plugin to minimize the size of the js assets. This is important especially when the project is deploy for PR preview (#438) or GitHub Pages (#439).
  - Update the `package.json` attributes for consistency with other projects and remove unused attributes.

### Notes

I have locally tested both the build and the development mode (the refresh still works for both TS code, HTML page and assets).
And I also check the PR preview.
The attributes in the `package.json` file has been changed as in #441