### PR TITLE
[FEAT] Bump BPMN vendor libs used in the misc examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -790,7 +790,7 @@ limitations under the License.
                                     <img src="static/img/preview/misc/compare-with-kie-editors-standalone.png" class="img-responsive" alt="compare with kie-editors-standalone">
                                 </div>
                                 <div class="card-body">Compare the libraries on BPMN elements rendering and API usage.<br>
-                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (12 MB, more than 2.5 MB after compression)
+                                    <b>WARN</b>: the <code>kie-editors-standalone</code> javascript resources are very large (12.5 MB, more than 3 MB after compression)
                                     and slow to initialize.</div>
                                 <div class="card-footer"></div>
                             </div>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@9.0.3/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-s/JkRyhKsh/RvFnHOHaBixwQtMShax4mAzW+SKvQWMU=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@11.1.1/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-m98lbCWcgMOn6QoSblajG1hCmn5+d4EJwooJENh+yBY=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.29.1/dist/bpmn-visualization.min.js"></script>
   <script defer src="shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/README.md
+++ b/examples/misc/compare-with-kie-editors-standalone/README.md
@@ -13,7 +13,7 @@ This example let you compare [`bpmn-visualization`](https://github.com/process-a
 
 **WARN** \
 The following applies at least to `kie-editors-standalone@0.13.0`
-- The javascript bundle is very large (12 MB, more than 2.5 MB after compression), very slow to load and generates a lot of error in the console.
+- The javascript bundle is very large (12.5 MB, more than 3 MB after compression), very slow to load and generates a lot of error in the console.
 - It is unable to display most of the C.x diagrams from the miwg-test-suite (parsing errors). See also [KOGITO-5395](https://issues.redhat.com/browse/KOGITO-5395).
 
 

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,8 +57,8 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.19.0/dist/bpmn/index.js"
-          integrity="sha256-UdaL91gCjylebTtxFlegIp+wveYHJYriiFtZmd8ssDY=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.26.0/dist/bpmn/index.js"
+          integrity="sha256-anZcLFSPz6/3m7qh5hNcD2d4YmHp8jRxXXzksmdU1yw=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.29.1/dist/bpmn-visualization.min.js"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
bpmn-js from 9.0.3 to 11.1.1
@kie-tools/kie-editors-standalone from 0.19.0 to 0.26.0

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/bump_bpmn_vendors_lib/examples/index.html


**Other information**

Previous bump: #329