### PR TITLE
chore: ensure that the PR title follows "Conventional Commits"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@ updates:
       day: wednesday
     open-pull-requests-limit: 2
     versioning-strategy: increase
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] prod -"
-      prefix-development: "[INFRA] dev -"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     reviewers:
       - process-analytics/pa-collaborators
 
@@ -22,8 +22,8 @@ updates:
       interval: "weekly"
       day: wednesday
     open-pull-requests-limit: 2
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] gha -"
+      prefix: "chore(gha)"
     reviewers:
       - process-analytics/pa-collaborators

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,21 +9,27 @@ Failure to do so may result in the rejection of the Pull Request.
 
 **Title**
 
-Put the title like `[KIND OF CHANGE] SHORT DESCRIPTION`
+Please follow ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) when creating the title.
 
-*KIND OF CHANGE* can be (see existing Pull Request for more elements):
-- DOC
-- FEAT
-- FIX
-- INFRA
-- REFACTOR
+It must look like `<type>[optional scope]: <lower case description>`
+
+*type* can be (see existing Pull Request for more elements):
+- chore
+- docs
+- feat
+- fix
+- refactor
 ...
+
+If defined, the _optional scope_ must be put in parentheses.
 
 _Note_: The title is used as proposal for the maintainer merging the Pull Request.
 
 **Details**
 
 Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?
+
+If the Pull Request includes breaking changes, it must explicitly follow the syntax proposed by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification).
 
 **On automatic closing of ISSUES**
 

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,14 @@
+name: Check Pull Request Metadata
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -47,14 +47,14 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-          commit-message: "[INFRA] Bump bpmn-visualization to ${{ env.VERSION }}"
+          commit-message: "chore(deps): bump bpmn-visualization to ${{ env.VERSION }}"
           committer: "process-analytics-bot <62586190+process-analytics-bot@users.noreply.github.com>"
           author: "process-analytics-bot <62586190+process-analytics-bot@users.noreply.github.com>"
-          branch: "infra/update_bpmn_visualization_to_${{ env.VERSION }}"
+          branch: "chore/update_bpmn_visualization_to_${{ env.VERSION }}"
           delete-branch: true
           base: "master"
-          title: "[INFRA] Bump bpmn-visualization to ${{ env.VERSION }}"
-          body: "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/infra/update_bpmn_visualization_to_${{ env.VERSION }}/examples/index.html"
+          title: "chore(deps): bump bpmn-visualization to ${{ env.VERSION }}"
+          body: "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/chore/update_bpmn_visualization_to_${{ env.VERSION }}/examples/index.html"
           labels: "enhancement"
           team-reviewers: pa-collaborators
           draft: true


### PR DESCRIPTION
Add a dedicated workflow to enforce the rule. It runs on `pull_request_target` to handle PR created by Dependabot and from fork repositories.
Dependabot configuration: change PR title prefix.
Update the GitHub workflows that create commits and PR. They now follow "conventional commits". Update the PR template to document the new syntax for the PR title.

closes #453

### Notes
For tests, see https://github.com/process-analytics/github-actions-playground/issues/213