### PR TITLE
fix(monitoring-demo-frequency): update the stroke of the overlays

### DIFF
--- a/demo/monitoring-all-process-instances/js/execution-data/execution-data.js
+++ b/demo/monitoring-all-process-instances/js/execution-data/execution-data.js
@@ -97,6 +97,10 @@ class ExecutionData {
 
     /**
      * Generic implementation
+     * @param {number} startIndex
+     * @param position {string}
+     * @param color {string}
+     * @returns {Map<string, {style: {fill: {color: string}}, position: string}>}
      */
     _internalBuildOverlayStyles(startIndex, position, color) {
         return new Map([
@@ -138,6 +142,11 @@ class ExecutionData {
 
     /**
      * Implementation required
+     *
+     * @param position {string}
+     * @param color {string}
+     * @returns {Map<string, {style: {fill: {color: string}, stroke?: {color: string}}, position: string}>}
+     * @private
      */
     _buildOverlayStyles(position, color) {
         throw new Error('Not implemented');

--- a/demo/monitoring-all-process-instances/js/execution-data/frequency-execution-data.js
+++ b/demo/monitoring-all-process-instances/js/execution-data/frequency-execution-data.js
@@ -27,7 +27,8 @@ class FrequencyExecutionData extends ExecutionData {
     _buildOverlayStyles(position, color) {
         const overlayStyles = this._internalBuildOverlayStyles(1, position, color);
         Array.from(overlayStyles.values()).forEach(overlayStyle => {
-            overlayStyle.stroke = {color: overlayStyle.style.fill.color};
+            const styleDefinition = overlayStyle.style;
+            styleDefinition.stroke = {color: styleDefinition.fill.color};
         });
         return overlayStyles;
     }


### PR DESCRIPTION
The stroke color should be the same as the fill color to demonstrate a non default stroke color (as already done in the time use case).
It had been put in black by mistake during a refactoring released with version 0.19.2. The stroke now always has the right color.

Also update the JSDoc (parameter types) of functions involved in the fix.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix/monitoring_demo_no_black_stroke_overlay_for_frequency_use_case/examples/index.html


### Screenshots

before ([0.30.0](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.30.0/demo/monitoring-all-process-instances/index.html)) | now
---- | ----
![image](https://user-images.githubusercontent.com/27200110/217884121-d33b01fe-20f0-42e2-8e91-3967cc6316a9.png) | ![image](https://user-images.githubusercontent.com/27200110/217884387-35938663-3dee-404c-bed2-5b7bc6442d16.png)


### Notes

PR title already ready to follow #454

Root cause of the issue: unwanted change introduced in #230
- worked with 0.19.1: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.19.1/demo/monitoring-all-process-instances/index.html
- ko in 0.19.2: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.19.2/demo/monitoring-all-process-instances/index.html

