### PR TITLE
feat(monitoring-demo): select use case with query parameter

### DIFF
--- a/demo/monitoring-all-process-instances/js/index.js
+++ b/demo/monitoring-all-process-instances/js/index.js
@@ -2,12 +2,20 @@
 const timeUseCase = new MonitoringUseCase('time', getHardwareRetailerDiagram, new TimeExecutionData());
 const frequencyUseCase = new MonitoringUseCase('frequency', getHardwareRetailerDiagram, new FrequencyExecutionData());
 
-// Initialize state of radio buttons
+/**
+ * @param {string} useCaseType
+ * @returns {MonitoringUseCase}
+ */
+const detectActualUseCase = useCaseType => useCaseType === 'frequency' ? frequencyUseCase : timeUseCase
+
+// Initialize the state and the radio buttons
+const parameters = new URLSearchParams(window.location.search);
+const useCaseType = ['frequency', 'time'].includes(parameters.get('useCase')) ? parameters.get('useCase') : 'time';
 const state = {
-    useCase: timeUseCase,
-    dataType: 'both'
+    useCase: detectActualUseCase(useCaseType),
+    dataType: ['both', 'overlays', 'paths'].includes(parameters.get('dataType')) ? parameters.get('dataType') : 'both'
 }
-document.getElementById('btn-time').checked = true;
+document.getElementById(`btn-${useCaseType}`).checked = true;
 document.getElementById(`btn-${state.dataType}`).checked = true;
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -17,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 document.getElementById('choose-use-case-panel').onchange = () => {
     const useCaseType = document.querySelector("input[type='radio'][name='use-case-type']:checked").value;
-    state.useCase = useCaseType === 'frequency' ? frequencyUseCase : timeUseCase;
+    state.useCase = detectActualUseCase(useCaseType);
 
     state.useCase.display(state.dataType);
 }

--- a/demo/monitoring-all-process-instances/js/index.js
+++ b/demo/monitoring-all-process-instances/js/index.js
@@ -10,12 +10,11 @@ const detectActualUseCase = useCaseType => useCaseType === 'frequency' ? frequen
 
 // Initialize the state and the radio buttons
 const parameters = new URLSearchParams(window.location.search);
-const useCaseType = ['frequency', 'time'].includes(parameters.get('useCase')) ? parameters.get('useCase') : 'time';
 const state = {
-    useCase: detectActualUseCase(useCaseType),
+    useCase: detectActualUseCase(['frequency', 'time'].includes(parameters.get('useCase')) ? parameters.get('useCase') : 'time'),
     dataType: ['both', 'overlays', 'paths'].includes(parameters.get('dataType')) ? parameters.get('dataType') : 'both'
 }
-document.getElementById(`btn-${useCaseType}`).checked = true;
+document.getElementById(`btn-${state.useCase.type}`).checked = true;
 document.getElementById(`btn-${state.dataType}`).checked = true;
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/demo/static/js/use-case.js
+++ b/demo/static/js/use-case.js
@@ -17,6 +17,10 @@ class UseCase {
         this.#loadOptions = {...defaultLoadOptions, ...loadOptions};
     }
 
+    get type() {
+        return this.#type;
+    }
+
     display(dataType) {
         this._displayPanel();
 


### PR DESCRIPTION
Introduce the `useCase` and `dataType` query parameters that let choose the use case (frequency, time) and the data type (both, overlays, paths).
This is useful to bookmark a URL for a specific demonstration or to automate screenshots.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/monitoring_demo_query_param_for_use_case_selection/examples/index.html

### Tested urls

- defaults (time and both) - same as before :https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/24966e0/demo/monitoring-all-process-instances/index.html
- frequency and overlays: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/24966e0/demo/monitoring-all-process-instances/index.html?useCase=frequency&dataType=overlays
- invalid useCase (so default "time") and paths: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/24966e0/demo/monitoring-all-process-instances/index.html?useCase=frequency2&dataType=paths
- invalid dataType, so default "both": https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/24966e0/demo/monitoring-all-process-instances/index.html?useCase=frequency&dataType=nothing

### Notes

We will be able to replicate this behavior for the Hacktoberfest demo, see #456