### PR TITLE
refactor(demo): move state from `PathUseCase` to `Steps` class on `draw-path` demo

### DIFF
--- a/demo/draw-path/js/steps.js
+++ b/demo/draw-path/js/steps.js
@@ -1,17 +1,55 @@
 class Steps {
 
+    #state;
+
+    constructor() {
+        this.reset();
+    }
+
+    get firstSelectedShapeId() {
+        return this.#state.firstSelectedShapeId;
+    }
+
+    hasNoSelectedShape() {
+        return !this.#state.firstSelectedShapeId;
+    }
+
+    hasOnlyOneSelectedShape() {
+        return this.#state.firstSelectedShapeId && !this.#state.secondSelectedShapeId ;
+    }
+
+    hasTwoSelectedShapes() {
+        return this.#state.firstSelectedShapeId && this.#state.secondSelectedShapeId;
+    }
+
     reset() {
+        this.#state = {
+            firstSelectedShapeId: undefined,
+            secondSelectedShapeId: undefined,
+        };
         this._goToStep(1);
     }
 
-    goToStep2(){
+    /**
+     * @param {string} firstSelectedShapeId
+     */
+    goToStep2(firstSelectedShapeId){
+        this.#state.firstSelectedShapeId = firstSelectedShapeId;
         this._goToStep(2);
     }
 
-    goToStep3(){
+    /**
+     * @param {string} secondSelectedShapeId
+     */
+    goToStep3(secondSelectedShapeId){
+        this.#state.secondSelectedShapeId = secondSelectedShapeId;
         this._goToStep(3);
     }
 
+    /**
+     * @param {number} index
+     * @private
+     */
     _goToStep(index) {
         const stepItems = document.getElementsByClassName("step-item");
         for (let stepItem of stepItems) {


### PR DESCRIPTION
- Make the properties of `PathUseCase` as private
- Move the `state` property and associated functions from `PathUseCase` to `Steps` class.
- Add JSDoc

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/refactor/move_state_from_PathUseCase_to_Steps/examples/index.html
