### PR TITLE
refactor: use the new "remove all CSS classes" API

### DIFF
--- a/demo/draw-path/js/style.js
+++ b/demo/draw-path/js/style.js
@@ -10,7 +10,7 @@ class Style {
      * @param {string[] | string} ids
      */
     reset(ids) {
-        this.#bpmnElementsRegistry.removeCssClasses(ids, ['disableAll', 'possibleNext', 'highlight', 'disablePointer']);
+        this.#bpmnElementsRegistry.removeAllCssClasses();
     }
 
     /**

--- a/examples/custom-behavior/apply-css-classes/index.js
+++ b/examples/custom-behavior/apply-css-classes/index.js
@@ -131,7 +131,7 @@ function applyInitialStyles() {
 }
 
 function clearAllStyles() {
-  removeCssClass(styledElements, 'highlight-info', 'highlight-success', 'highlight-error', 'highlight-warning')
+  bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses();
   clearHighlightPath();
 }
 


### PR DESCRIPTION
This API was introduced in `bpmn-visualization@0.34.0`.

### Notes

See https://github.com/process-analytics/bpmn-visualization-js/issues/2576

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/bb70581f5ee85826e13cdcd5ac8f5a410875371c/examples/index.html
