### PR TITLE
chore: bump parcel from 2.8.3 to 2.9.0

### DIFF
--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,9 +11,9 @@
     "bpmn-visualization": "0.34.1"
   },
   "devDependencies": {
-    "@parcel/core": "~2.8.3",
-    "@parcel/transformer-inline-string": "~2.8.3",
-    "parcel": "~2.8.3",
+    "@parcel/core": "~2.9.0",
+    "@parcel/transformer-inline-string": "~2.9.0",
+    "parcel": "~2.9.0",
     "typescript": "~4.5.5"
   }
 }


### PR DESCRIPTION
### Notes

parcel: https://github.com/parcel-bundler/parcel/releases/tag/v2.9.0
Tested locally in dev mode.