### PR TITLE
fix: configure custom default fonts and colors

### DIFF
--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -25,32 +25,16 @@ Content:
 StyleDefault.DEFAULT_FONT_COLOR = 'Cyan';
 ```
 
-- override default fill and stroke colors: extend the lib class entry point
+- override default fill and stroke colors: update the `StyleDefault` default values
 ```javascript
-class BpmnVisualizationCustomDefaultColors extends BpmnVisualizationCustomizedColors {
-  constructor(containerId) {
-    super({ container: containerId });
-    this.configureStyle();
-  }
-
-  configureStyle() {
-    const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
-
-    const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
-    defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
-    defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
-
-    const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
-    defaultEdgeStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
-  }
-}
-
-const bpmnVisualizationCustomDefaultColors = new BpmnVisualizationCustomDefaultColors('bpmn-container-custom-default-colors');
+StyleDefault.DEFAULT_FILL_COLOR = 'LemonChiffon';
+StyleDefault.DEFAULT_STROKE_COLOR = 'Orange';
 ```
 
 - different fill and stroke colors for `event`, `gateway` and `task`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomColors extends BpmnVisualization {
+
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();
@@ -81,6 +65,7 @@ const bpmnVisualizationCustomColors = new BpmnVisualizationCustomColors('bpmn-co
 - different fill and stroke colors for `events`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomEventColors extends BpmnVisualization {
+
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();
@@ -105,6 +90,7 @@ const bpmnVisualizationEventCustomColors = new BpmnVisualizationCustomEventColor
 - specific font color for ` user task`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomColorsUserTask extends BpmnVisualization {
+
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();

--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -25,20 +25,32 @@ Content:
 StyleDefault.DEFAULT_FONT_COLOR = 'Cyan';
 ```
 
-- override default fill and stroke colors: update the `StyleConfigurator` method
+- override default fill and stroke colors: extend the lib class entry point
 ```javascript
-const originalConfigureCommonDefaultStyle = StyleConfigurator.configureCommonDefaultStyle;
-StyleConfigurator.configureCommonDefaultStyle = function (style) {
-    originalConfigureCommonDefaultStyle(style);
-    style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
-    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+class BpmnVisualizationCustomDefaultColors extends BpmnVisualizationCustomizedColors {
+  constructor(containerId) {
+    super({ container: containerId });
+    this.configureStyle();
+  }
+
+  configureStyle() {
+    const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
+
+    const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+    defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+    defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+
+    const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
+    defaultEdgeStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+  }
 }
+
+const bpmnVisualizationCustomDefaultColors = new BpmnVisualizationCustomDefaultColors('bpmn-container-custom-default-colors');
 ```
 
 - different fill and stroke colors for `event`, `gateway` and `task`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomColors extends BpmnVisualization {
-
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();
@@ -69,7 +81,6 @@ const bpmnVisualizationCustomColors = new BpmnVisualizationCustomColors('bpmn-co
 - different fill and stroke colors for `events`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomEventColors extends BpmnVisualization {
-
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();
@@ -94,7 +105,6 @@ const bpmnVisualizationEventCustomColors = new BpmnVisualizationCustomEventColor
 - specific font color for ` user task`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomColorsUserTask extends BpmnVisualization {
-
     constructor(containerId) {
         super({ container: containerId });
         this.configureStyle();

--- a/examples/custom-bpmn-theme/custom-colors/index.js
+++ b/examples/custom-bpmn-theme/custom-colors/index.js
@@ -15,35 +15,8 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = 'DeepPink';
 const bpmnVisualizationCustomDefaultFontColor = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-font-color' });
 bpmnVisualizationCustomDefaultFontColor.load(bpmn);
 
-// restore StyleConstant defaults
+// restore StyleDefault
 bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = originalDefaultFontColor;
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// custom default fill and stroke colors
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-const originalConfigureDefaultVertexStyle = bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle;
-bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle = function() {
-    originalConfigureDefaultVertexStyle.apply(this);
-
-    const style = this.getStylesheet().getDefaultVertexStyle();
-    style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
-    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
-}
-const originalConfigureDefaultEdgeStyle = bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle;
-bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle = function() {
-    originalConfigureDefaultEdgeStyle.apply(this);
-
-    const style = this.getStylesheet().getDefaultEdgeStyle();
-    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
-}
-
-const bpmnVisualizationCustomDefaultColor = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-colors' });
-bpmnVisualizationCustomDefaultColor.load(bpmn);
-
-// restore StyleConfigurator defaults
-bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle= originalConfigureDefaultVertexStyle;
-bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle= originalConfigureDefaultEdgeStyle;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +33,28 @@ class BpmnVisualizationCustomizedColors extends bpmnvisu.BpmnVisualization {
         // do nothing by default
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// custom default fill and stroke colors
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const customDefaultStrokeColor = 'Orange';
+class BpmnVisualizationCustomDefaultColors extends BpmnVisualizationCustomizedColors {
+    configureStyle() {
+        const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
+
+        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+        defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+        defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = customDefaultStrokeColor;
+
+        const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
+        defaultEdgeStyle[StyleIdentifiers.STYLE_STROKECOLOR] = customDefaultStrokeColor;
+    }
+}
+
+const bpmnVisualizationCustomDefaultColors = new BpmnVisualizationCustomDefaultColors('bpmn-container-custom-default-colors');
+bpmnVisualizationCustomDefaultColors.load(bpmn);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/custom-bpmn-theme/custom-colors/index.js
+++ b/examples/custom-bpmn-theme/custom-colors/index.js
@@ -22,10 +22,19 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = originalDefaultFontColor;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // custom default fill and stroke colors
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-const originalConfigureCommonDefaultStyle = bpmnvisu.StyleConfigurator.configureCommonDefaultStyle;
-bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = function (style) {
-    originalConfigureCommonDefaultStyle(style);
+const originalConfigureDefaultVertexStyle = bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle;
+bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle = function() {
+    originalConfigureDefaultVertexStyle.apply(this);
+
+    const style = this.getStylesheet().getDefaultVertexStyle();
     style[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+    style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+}
+const originalConfigureDefaultEdgeStyle = bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle;
+bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle = function() {
+    originalConfigureDefaultEdgeStyle.apply(this);
+
+    const style = this.getStylesheet().getDefaultEdgeStyle();
     style[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
 }
 
@@ -33,7 +42,8 @@ const bpmnVisualizationCustomDefaultColor = new bpmnvisu.BpmnVisualization({ con
 bpmnVisualizationCustomDefaultColor.load(bpmn);
 
 // restore StyleConfigurator defaults
-bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = originalConfigureCommonDefaultStyle;
+bpmnvisu.StyleConfigurator.prototype.configureDefaultVertexStyle= originalConfigureDefaultVertexStyle;
+bpmnvisu.StyleConfigurator.prototype.configureDefaultEdgeStyle= originalConfigureDefaultEdgeStyle;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/custom-bpmn-theme/custom-colors/index.js
+++ b/examples/custom-bpmn-theme/custom-colors/index.js
@@ -20,6 +20,23 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = originalDefaultFontColor;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// custom default fill and stroke colors
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const originalFillColor = bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR;
+const originalStrokeColor = bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR;
+bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR = 'LemonChiffon';
+bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR = 'Orange';
+
+const bpmnVisualizationCustomDefaultColors = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-colors' });
+bpmnVisualizationCustomDefaultColors.load(bpmn);
+
+// restore StyleDefault
+bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR = originalFillColor;
+bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR = originalStrokeColor;
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // shared config
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -33,28 +50,6 @@ class BpmnVisualizationCustomizedColors extends bpmnvisu.BpmnVisualization {
         // do nothing by default
     }
 }
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// custom default fill and stroke colors
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-const customDefaultStrokeColor = 'Orange';
-class BpmnVisualizationCustomDefaultColors extends BpmnVisualizationCustomizedColors {
-    configureStyle() {
-        const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
-
-        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
-        defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
-        defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = customDefaultStrokeColor;
-
-        const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
-        defaultEdgeStyle[StyleIdentifiers.STYLE_STROKECOLOR] = customDefaultStrokeColor;
-    }
-}
-
-const bpmnVisualizationCustomDefaultColors = new BpmnVisualizationCustomDefaultColors('bpmn-container-custom-default-colors');
-bpmnVisualizationCustomDefaultColors.load(bpmn);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/custom-bpmn-theme/custom-fonts/README.md
+++ b/examples/custom-bpmn-theme/custom-fonts/README.md
@@ -28,14 +28,6 @@ Content:
   StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
 ```
 
-  - update the `StyleConfigurator` method
-```javascript
-StyleConfigurator.configureCommonDefaultStyle = function (style) {
-    originalConfigureCommonDefaultStyle(style);
-    style[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
-}
-```
-
 - different fonts for `event`, `gateway` and `task`: extend the lib class entry point
 ```javascript
 class BpmnVisualizationCustomFonts extends BpmnVisualization {

--- a/examples/custom-bpmn-theme/custom-fonts/index.js
+++ b/examples/custom-bpmn-theme/custom-fonts/index.js
@@ -16,21 +16,31 @@ const originalDefaultFontSize = bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE;
 bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = '12';
 bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
 
-const originalConfigureCommonDefaultStyle = bpmnvisu.StyleConfigurator.configureCommonDefaultStyle;
-console.warn("### define code for 'custom default fill and stroke colors'")
-bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = function (style) {
-    console.warn('@@@Custom StyleConfigurator')
-    originalConfigureCommonDefaultStyle(style);
-    style[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+class BpmnVisualizationCustomDefaultFont extends bpmnvisu.BpmnVisualization {
+
+    constructor(containerId) {
+        super({ container: containerId });
+        this.configureStyle();
+    }
+
+    configureStyle() {
+        const styleSheet = this.graph.getStylesheet(); // mxStylesheet
+
+        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+        defaultVertexStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+
+        const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
+        defaultEdgeStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+    }
+
 }
 
-const bpmnVisualizationCustomDefaultFont = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-font' });
+const bpmnVisualizationCustomDefaultFont = new BpmnVisualizationCustomDefaultFont('bpmn-container-custom-default-font');
 bpmnVisualizationCustomDefaultFont.load(bpmn);
 
+// restore StyleDefault
 bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = originalDefaultFontFamily;
 bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = originalDefaultFontSize;
-// restore StyleConfigurator defaults
-bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = originalConfigureCommonDefaultStyle;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -61,4 +71,3 @@ class BpmnVisualizationCustomFonts extends bpmnvisu.BpmnVisualization {
 
 const bpmnVisualizationCustomFonts = new BpmnVisualizationCustomFonts('bpmn-container-custom-fonts');
 bpmnVisualizationCustomFonts.load(bpmn);
-

--- a/examples/custom-bpmn-theme/custom-fonts/index.js
+++ b/examples/custom-bpmn-theme/custom-fonts/index.js
@@ -17,7 +17,9 @@ bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = '12';
 bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
 
 const originalConfigureCommonDefaultStyle = bpmnvisu.StyleConfigurator.configureCommonDefaultStyle;
+console.warn("### define code for 'custom default fill and stroke colors'")
 bpmnvisu.StyleConfigurator.configureCommonDefaultStyle = function (style) {
+    console.warn('@@@Custom StyleConfigurator')
     originalConfigureCommonDefaultStyle(style);
     style[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
 }


### PR DESCRIPTION
Do not rely on `StyleConfigurator` which is experimental. Use a more stable implementation.
The example previously relied on a private method which was removed in v0.29.2.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/38a6fec/examples/index.html

### Notes

I considered several implementations for the "default colors" examples that had the issue
- prototype based: adapt the previous implementation. Not readable, complicated, highly thight on a private method of `StyleConfigurator`. 144ca86
- class based: call a "configureStyle" methods after the lib initialization, as we do in other examples. 15e2edf
- StyleDefault. I finally ends with this one as it is simpler to only change the defaults. 38a6fec 

For the "default fonts" example, I only implemented the "StyleDefault" way.


As we are not using `StyleConfigurator` and we have simpler implementations, I am going to remove it from the public API as it is part of the internals of the lib. Later, we will propose a public API with https://github.com/process-analytics/bpmn-visualization-js/issues/2471 

### Root cause

The issue has been introduced in https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.29.2.
A private method of the `StyleConfigurator` overridden in the examples was removed: https://github.com/process-analytics/bpmn-visualization-js/pull/2462.


Custom Default Colors example
[0.29.1](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.29.1/examples/custom-bpmn-theme/custom-colors/index.html) | [0.29.2](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.29.2/examples/custom-bpmn-theme/custom-colors/index.html)
----- | -----
![image](https://github.com/process-analytics/bpmn-visualization-examples/assets/27200110/ab911b48-b09a-4f62-95a8-1cf9dca527f9) | ![image](https://github.com/process-analytics/bpmn-visualization-examples/assets/27200110/9d0c386e-2b3d-4019-84b2-f0d3043c607a)

