### PR TITLE
refactor: extract the styling for the prediction demo in dedicated classes

### DIFF
--- a/demo/predictions/index.html
+++ b/demo/predictions/index.html
@@ -28,7 +28,7 @@ limitations under the License.
     <script defer src="../../examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js"></script>
     <script defer src="../static/js/use-case.js"></script>
     <script defer src="./js/data.js"></script>
-    <script defer src="./js/style-manager.js"></script>
+    <script defer src="./js/style.js"></script>
     <script defer src="./js/prediction-use-case.js"></script>
     <script defer src="./js/index.js"></script>
 </head>

--- a/demo/predictions/index.html
+++ b/demo/predictions/index.html
@@ -28,6 +28,7 @@ limitations under the License.
     <script defer src="../../examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js"></script>
     <script defer src="../static/js/use-case.js"></script>
     <script defer src="./js/data.js"></script>
+    <script defer src="./js/style-manager.js"></script>
     <script defer src="./js/prediction-use-case.js"></script>
     <script defer src="./js/index.js"></script>
 </head>

--- a/demo/predictions/js/data.js
+++ b/demo/predictions/js/data.js
@@ -46,28 +46,22 @@ class ExecutionData {
 
 class PredicatedLateExecutionData extends ExecutionData {
 
-    _runningElementWithPrediction = {
-        bpmnId: this._vendorBakeThePizzaId,
-        cssClasses: 'state-predicted-late',
-    };
+    _runningElementWithPrediction = this._vendorBakeThePizzaId;
 
-    _predictedPaths = {
-        ids: [
-            // customer elements
-            this._customerEvtBasedGwId,
-            '_6-424', // sequence flow between 'event-based gateway' (running element) and timer event
-            '_6-219', // timer event
-            '_6-426', // sequence flow between 'timer event' and 'Ask for the pizza'
-            '_6-236', // 'Ask for the pizza'
-            // message flow
-            '_6-642',
-            // vendor elements
-            this._vendorWhereIsMyPizzaId,
-            '_6-748', // sequence flow between 'where is my pizza' and 'Calm customer'
-            '_6-695', // 'Calm customer'
-        ],
-        cssClasses: 'path-predicted-late',
-    };
+    _predictedPaths = [
+        // customer elements
+        this._customerEvtBasedGwId,
+        '_6-424', // sequence flow between 'event-based gateway' (running element) and timer event
+        '_6-219', // timer event
+        '_6-426', // sequence flow between 'timer event' and 'Ask for the pizza'
+        '_6-236', // 'Ask for the pizza'
+        // message flow
+        '_6-642',
+        // vendor elements
+        this._vendorWhereIsMyPizzaId,
+        '_6-748', // sequence flow between 'where is my pizza' and 'Calm customer'
+        '_6-695', // 'Calm customer'
+    ];
 
     get executedElements() {
         return this._commonExecutedElements;
@@ -85,27 +79,22 @@ class PredicatedLateExecutionData extends ExecutionData {
 
 class PredictedOnTimeExecutionData extends ExecutionData {
 
-    _runningElementWithPrediction = {
-        bpmnId: '_6-514', // vendor 'Deliver the pizza'
-        cssClasses: 'state-predicted-on-time',
-    };
+    // vendor 'Deliver the pizza'
+    _runningElementWithPrediction = '_6-514';
 
-    _predictedPaths = {
-        ids: [
-            // customer elements
-            this._customerEvtBasedGwId,
-            '_6-422', // sequence flow between 'event-based gateway' (running element) and msg event
-            '_6-202', // msg event 'Pizza received'
-            '_6-428', // sequence flow between 'msg event' and 'Pay the pizza'
-            '_6-304', // 'Pay the pizza'
-            // message flow
-            '_6-640', // from vendor 'Deliver the pizza' to customer 'msg event'
-            // vendor elements
-            '_6-634', // sequence flow between 'Deliver the pizza' and 'Receive payment'
-            '_6-565', // 'Receive payment'
-        ],
-        cssClasses: 'path-predicted-on-time'
-    };
+    _predictedPaths = [
+        // customer elements
+        this._customerEvtBasedGwId,
+        '_6-422', // sequence flow between 'event-based gateway' (running element) and msg event
+        '_6-202', // msg event 'Pizza received'
+        '_6-428', // sequence flow between 'msg event' and 'Pay the pizza'
+        '_6-304', // 'Pay the pizza'
+        // message flow
+        '_6-640', // from vendor 'Deliver the pizza' to customer 'msg event'
+        // vendor elements
+        '_6-634', // sequence flow between 'Deliver the pizza' and 'Receive payment'
+        '_6-565', // 'Receive payment'
+    ];
 
     _executedElements = [...this._commonExecutedElements,
         // vendor

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -1,6 +1,6 @@
 class PredicatedLateUseCase extends UseCase {
 
-    _styleManager;
+    _style;
     _executionData;
 
     constructor(type) {
@@ -11,14 +11,14 @@ class PredicatedLateUseCase extends UseCase {
     _postLoadDiagram() {
         this._initManager();
 
-        this._styleManager.reduceVisibilityOfExecutedElements(this._dataExecutionManager.executedElements);
-        this._styleManager.highlightRunningElementsWithPrediction(this._dataExecutionManager.runningElementWithPrediction);
-        this._styleManager.toggleHighlightRunningElementsWithoutPrediction(this._dataExecutionManager.runningElementsWithoutPrediction);
-        this._registerInteractions(this._dataExecutionManager.predictedPaths, this._dataExecutionManager.runningElementsWithoutPrediction, this._dataExecutionManager.runningElementWithPrediction);
+        this._style.reduceVisibilityOfExecutedElements(this._executionData.executedElements);
+        this._style.highlightRunningElementsWithPrediction(this._executionData.runningElementWithPrediction);
+        this._style.toggleHighlightRunningElementsWithoutPrediction(this._executionData.runningElementsWithoutPrediction);
+        this._registerInteractions(this._executionData.predictedPaths, this._executionData.runningElementsWithoutPrediction, this._executionData.runningElementWithPrediction);
     }
 
     _initManager() {
-        this._styleManager = new PredicatedLateStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
+        this._style = new PredicatedLateStyle(this._bpmnVisualization.bpmnElementsRegistry);
     }
 
     _registerInteractions(predictedPath, runningElementsWithoutPrediction, runningElementWithPrediction) {
@@ -26,8 +26,8 @@ class PredicatedLateUseCase extends UseCase {
         const elementTogglingPath = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(runningElementWithPrediction)[0]; // exist and only one
 
         const highlightPredictedPath = () => {
-            this._styleManager.toggleHighlightRunningElementsWithoutPrediction(runningElementsWithoutPrediction);
-            this._styleManager.toggleHighlightPredictedPath(predictedPath);
+            this._style.toggleHighlightRunningElementsWithoutPrediction(runningElementsWithoutPrediction);
+            this._style.toggleHighlightPredictedPath(predictedPath);
         }
 
         elementTogglingPath.htmlElement.addEventListener('mouseenter', highlightPredictedPath);
@@ -43,6 +43,6 @@ class PredictedOnTimeUseCase extends PredicatedLateUseCase {
     }
     
     _initManager() {
-        this._styleManager = new PredictedOnTimeStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
+        this._style = new PredictedOnTimeStyle(this._bpmnVisualization.bpmnElementsRegistry);
     }
 }

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -1,15 +1,24 @@
 class PredicatedLateUseCase extends UseCase {
+
+    _styleManager;
+    _executionData;
+
     constructor(type) {
         super(type, () => pizzaDiagram(), true, {fit: {type: 'Center', margin: 20}});
-        this._styleManager = new PredicatedLateStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
         this._executionData = new PredicatedLateExecutionData();
     }
 
     _postLoadDiagram() {
+        this._initManager();
+
         this._styleManager.reduceVisibilityOfExecutedElements(this._dataExecutionManager.executedElements);
         this._styleManager.highlightRunningElementsWithPrediction(this._dataExecutionManager.runningElementWithPrediction);
         this._styleManager.toggleHighlightRunningElementsWithoutPrediction(this._dataExecutionManager.runningElementsWithoutPrediction);
         this._registerInteractions(this._dataExecutionManager.predictedPaths, this._dataExecutionManager.runningElementsWithoutPrediction, this._dataExecutionManager.runningElementWithPrediction);
+    }
+
+    _initManager() {
+        this._styleManager = new PredicatedLateStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
     }
 
     _registerInteractions(predictedPath, runningElementsWithoutPrediction, runningElementWithPrediction) {
@@ -30,7 +39,10 @@ class PredicatedLateUseCase extends UseCase {
 class PredictedOnTimeUseCase extends PredicatedLateUseCase {
     constructor(type) {
         super(type);
-        this._styleManager = new PredictedOnTimeStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
         this._executionData = new PredictedOnTimeExecutionData();
+    }
+    
+    _initManager() {
+        this._styleManager = new PredictedOnTimeStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
     }
 }

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -1,41 +1,28 @@
 class PredicatedLateUseCase extends UseCase {
     constructor(type) {
         super(type, () => pizzaDiagram(), true, {fit: {type: 'Center', margin: 20}});
+        this._styleManager = new PredicatedLateStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
         this._executionData = new PredicatedLateExecutionData();
     }
 
     _postLoadDiagram() {
-        this._reduceVisibilityOfAlreadyExecutedElements();
-        this._highlightRunningElementsWithPrediction();
-        this._toggleHighlightRunningElementsWithoutPrediction();
-        this._registerInteractions();
+        this._styleManager.reduceVisibilityOfExecutedElements(this._dataExecutionManager.executedElements);
+        this._styleManager.highlightRunningElementsWithPrediction(this._dataExecutionManager.runningElementWithPrediction);
+        this._styleManager.toggleHighlightRunningElementsWithoutPrediction(this._dataExecutionManager.runningElementsWithoutPrediction);
+        this._registerInteractions(this._dataExecutionManager.predictedPaths, this._dataExecutionManager.runningElementsWithoutPrediction, this._dataExecutionManager.runningElementWithPrediction);
     }
 
-    _reduceVisibilityOfAlreadyExecutedElements() {
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(this._executionData.executedElements, 'state-already-executed');
-    }
-
-    _registerInteractions() {
+    _registerInteractions(predictedPath, runningElementsWithoutPrediction, runningElementWithPrediction) {
         // on hover, highlight the predicted path
-        const elementTogglingPath = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(this._executionData.runningElementWithPrediction.bpmnId)[0]; // exist and only one
+        const elementTogglingPath = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(runningElementWithPrediction)[0]; // exist and only one
 
         const highlightPredictedPath = () => {
-            this._toggleHighlightRunningElementsWithoutPrediction();
-            const predictedPath = this._executionData.predictedPaths;
-            this._bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(predictedPath.ids, predictedPath.cssClasses);
+            this._styleManager.toggleHighlightRunningElementsWithoutPrediction(runningElementsWithoutPrediction);
+            this._styleManager.toggleHighlightPredictedPath(predictedPath);
         }
 
         elementTogglingPath.htmlElement.addEventListener('mouseenter', highlightPredictedPath);
         elementTogglingPath.htmlElement.addEventListener('mouseleave', highlightPredictedPath);
-    }
-
-    _toggleHighlightRunningElementsWithoutPrediction() {
-        this._bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(this._executionData.runningElementsWithoutPrediction, 'state-running');
-    }
-
-    _highlightRunningElementsWithPrediction() {
-        const elementWithPrediction =  this._executionData.runningElementWithPrediction;
-        this._bpmnVisualization.bpmnElementsRegistry.addCssClasses(elementWithPrediction.bpmnId, elementWithPrediction.cssClasses);
     }
 }
 
@@ -43,6 +30,7 @@ class PredicatedLateUseCase extends UseCase {
 class PredictedOnTimeUseCase extends PredicatedLateUseCase {
     constructor(type) {
         super(type);
+        this._styleManager = new PredictedOnTimeStyleManager(this._bpmnVisualization.bpmnElementsRegistry);
         this._executionData = new PredictedOnTimeExecutionData();
     }
 }

--- a/demo/predictions/js/style-manager.js
+++ b/demo/predictions/js/style-manager.js
@@ -50,7 +50,7 @@ class PredicatedLateStyleManager extends StyleManager {
      * @param {string[] | string} ids
      */
     highlightRunningElementsWithPrediction(ids) {
-        this._bpmnElementsRegistry.bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-late');
+        this._bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-late');
     }
 }
 
@@ -72,6 +72,6 @@ class PredictedOnTimeStyleManager extends StyleManager {
      * @param {string[] | string} ids
      */
     highlightRunningElementsWithPrediction(ids) {
-        this._bpmnElementsRegistry.bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-on-time');
+        this._bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-on-time');
     }
 }

--- a/demo/predictions/js/style-manager.js
+++ b/demo/predictions/js/style-manager.js
@@ -1,0 +1,77 @@
+class StyleManager {
+
+    _bpmnElementsRegistry;
+
+    constructor(bpmnElementsRegistry) {
+        this._bpmnElementsRegistry = bpmnElementsRegistry;
+    }
+
+    /**
+     * @param {string[]} ids
+     */
+    reduceVisibilityOfExecutedElements(ids) {
+        this._bpmnElementsRegistry.addCssClasses(ids, 'state-already-executed');
+    }
+
+    /**
+     * @param {string[]} ids
+     */
+    toggleHighlightRunningElementsWithoutPrediction(ids) {
+        this._bpmnElementsRegistry.toggleCssClasses(ids, 'state-running');
+    }
+
+    /**
+     * @param {string[]} ids
+     */
+    toggleHighlightPredictedPath(ids) {
+    }
+
+    /**
+     * @param {string[] | string} ids
+     */
+    highlightRunningElementsWithPrediction(ids) {
+    }
+}
+
+class PredicatedLateStyleManager extends StyleManager {
+
+    constructor(bpmnElementsRegistry) {
+       super(bpmnElementsRegistry);
+    }
+
+    /**
+     * @param {string[]} ids
+     */
+    toggleHighlightPredictedPath(ids) {
+        this._bpmnElementsRegistry.toggleCssClasses(ids, 'path-predicted-late');
+    }
+
+    /**
+     * @param {string[] | string} ids
+     */
+    highlightRunningElementsWithPrediction(ids) {
+        this._bpmnElementsRegistry.bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-late');
+    }
+}
+
+
+class PredictedOnTimeStyleManager extends StyleManager {
+
+    constructor(bpmnElementsRegistry) {
+        super(bpmnElementsRegistry);
+    }
+
+    /**
+     * @param {string[]} ids
+     */
+    toggleHighlightPredictedPath(ids) {
+        this._bpmnElementsRegistry.toggleCssClasses(ids, 'path-predicted-on-time');
+    }
+
+    /**
+     * @param {string[] | string} ids
+     */
+    highlightRunningElementsWithPrediction(ids) {
+        this._bpmnElementsRegistry.bpmnElementsRegistry.addCssClasses(ids, 'state-predicted-on-time');
+    }
+}

--- a/demo/predictions/js/style.js
+++ b/demo/predictions/js/style.js
@@ -1,4 +1,4 @@
-class StyleManager {
+class Style {
 
     _bpmnElementsRegistry;
 
@@ -33,7 +33,7 @@ class StyleManager {
     }
 }
 
-class PredicatedLateStyleManager extends StyleManager {
+class PredicatedLateStyle extends Style {
 
     constructor(bpmnElementsRegistry) {
        super(bpmnElementsRegistry);
@@ -55,7 +55,7 @@ class PredicatedLateStyleManager extends StyleManager {
 }
 
 
-class PredictedOnTimeStyleManager extends StyleManager {
+class PredictedOnTimeStyle extends Style {
 
     constructor(bpmnElementsRegistry) {
         super(bpmnElementsRegistry);


### PR DESCRIPTION
**Live environment of examples**

[https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/extract_prediction_style/demo/predictions/index.html](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/extract_prediction_style/demo/predictions/index.html)  
  
last commit: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/0f8456c3c834f15c453ea3c07a187dd06498c962/demo/predictions/index.html

Depends on #513