### PR TITLE
refactor(theme): use global style instead of StyleDefault

### DIFF
--- a/examples/custom-bpmn-theme/custom-colors/README.md
+++ b/examples/custom-bpmn-theme/custom-colors/README.md
@@ -20,15 +20,17 @@ We are using `Directions` and `StyleIdentifiers` here that store the constants s
 But you can also use the string value directly, for instance `style['fillColor']=...`.
 
 Content:
-- override default font color: update the `StyleDefault` default values
-```javascript
-StyleDefault.DEFAULT_FONT_COLOR = 'Cyan';
-```
-
-- override default fill and stroke colors: update the `StyleDefault` default values
-```javascript
-StyleDefault.DEFAULT_FILL_COLOR = 'LemonChiffon';
-StyleDefault.DEFAULT_STROKE_COLOR = 'Orange';
+- override default font color or default fill and stroke colors: 
+```js
+configureStyle() {
+    const styleSheet = this.graph.getStylesheet(); // mxStylesheet
+  // edge
+  styleSheet.getDefaultEdgeStyle()[StyleIdentifiers.STYLE_STROKECOLOR] = 'Gray';
+  // vertex
+  const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+  defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+  defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Chartreuse';
+}
 ```
 
 - different fill and stroke colors for `event`, `gateway` and `task`: extend the lib class entry point

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -25,7 +25,6 @@ limitations under the License.
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.37.0/dist/bpmn-visualization.min.js"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script defer src="../../static/js/style-defaults.js"></script>
     <script defer src="../../static/js/style-identifiers.js"></script>
     <script defer src="index.js"></script>
 </head>

--- a/examples/custom-bpmn-theme/custom-colors/index.js
+++ b/examples/custom-bpmn-theme/custom-colors/index.js
@@ -8,27 +8,6 @@ bpmnVisualization.load(bpmn);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// custom default font color
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-bpmnvisu.StyleDefault.DEFAULT_FONT_COLOR = 'DeepPink';
-const bpmnVisualizationCustomDefaultFontColor = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-font-color' });
-bpmnVisualizationCustomDefaultFontColor.load(bpmn);
-resetStyleDefault();
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// custom default fill and stroke colors
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bpmnvisu.StyleDefault.DEFAULT_FILL_COLOR = 'LemonChiffon';
-bpmnvisu.StyleDefault.DEFAULT_STROKE_COLOR = 'Orange';
-
-const bpmnVisualizationCustomDefaultColors = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container-custom-default-colors' });
-bpmnVisualizationCustomDefaultColors.load(bpmn);
-resetStyleDefault();
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // shared config
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -42,6 +21,45 @@ class BpmnVisualizationCustomizedColors extends bpmnvisu.BpmnVisualization {
         // do nothing by default
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// custom default font color
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class BpmnVisualizationCustomDefaultFontColor extends BpmnVisualizationCustomizedColors {
+    configureStyle() {
+        const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
+        const defaultFontColor = 'DeepPink';
+        // edge
+        styleSheet.getDefaultEdgeStyle()[StyleIdentifiers.STYLE_FONTCOLOR] = defaultFontColor;
+        // vertex
+        styleSheet.getDefaultVertexStyle()[StyleIdentifiers.STYLE_FONTCOLOR] = defaultFontColor;
+    }
+}
+
+const bpmnVisualizationCustomDefaultFontColor = new BpmnVisualizationCustomDefaultFontColor('bpmn-container-custom-font-color');
+bpmnVisualizationCustomDefaultFontColor.load(bpmn);
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// custom default fill and stroke colors
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class BpmnVisualizationCustomDefaultFillAndStrokeColors extends BpmnVisualizationCustomizedColors {
+    configureStyle() {
+        const styleSheet = this.graph.getStylesheet(); // mxStylesheet parameter
+        // edge
+        styleSheet.getDefaultEdgeStyle()[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+        // vertex
+        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+        defaultVertexStyle[StyleIdentifiers.STYLE_FILLCOLOR] = 'LemonChiffon';
+        defaultVertexStyle[StyleIdentifiers.STYLE_STROKECOLOR] = 'Orange';
+    }
+}
+
+const bpmnVisualizationCustomDefaultColors = new BpmnVisualizationCustomDefaultFillAndStrokeColors('bpmn-container-custom-default-colors');
+bpmnVisualizationCustomDefaultColors.load(bpmn);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/custom-bpmn-theme/custom-fonts/README.md
+++ b/examples/custom-bpmn-theme/custom-fonts/README.md
@@ -22,10 +22,20 @@ But you can also use the string value directly, for instance `style['fontStyle']
 
 Content:
 - override default font: 
-  - update the `StyleDefault` default values
-```javascript
-  StyleDefault.DEFAULT_FONT_SIZE = '12';
-  StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
+```js
+configureStyle() {
+  const styleSheet = this.graph.getStylesheet(); // mxStylesheet
+  // edge
+  const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
+  defaultEdgeStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+  defaultEdgeStyle[StyleIdentifiers.STYLE_FONTSIZE] = 12;
+  defaultEdgeStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+  // vertex
+  const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+  defaultVertexStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+  defaultVertexStyle[StyleIdentifiers.STYLE_FONTSIZE] = 12;
+  defaultVertexStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+}
 ```
 
 - different fonts for `event`, `gateway` and `task`: extend the lib class entry point

--- a/examples/custom-bpmn-theme/custom-fonts/index.html
+++ b/examples/custom-bpmn-theme/custom-fonts/index.html
@@ -25,7 +25,6 @@ limitations under the License.
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.37.0/dist/bpmn-visualization.min.js"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
-    <script defer src="../../static/js/style-defaults.js"></script>
     <script defer src="../../static/js/style-identifiers.js"></script>
     <script defer src="index.js"></script>
 </head>

--- a/examples/custom-bpmn-theme/custom-fonts/index.js
+++ b/examples/custom-bpmn-theme/custom-fonts/index.js
@@ -10,8 +10,6 @@ bpmnVisualization.load(bpmn);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // custom default font
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-bpmnvisu.StyleDefault.DEFAULT_FONT_SIZE = '12';
-bpmnvisu.StyleDefault.DEFAULT_FONT_FAMILY = 'Courier New,serif';
 
 class BpmnVisualizationCustomDefaultFont extends bpmnvisu.BpmnVisualization {
 
@@ -22,19 +20,21 @@ class BpmnVisualizationCustomDefaultFont extends bpmnvisu.BpmnVisualization {
 
     configureStyle() {
         const styleSheet = this.graph.getStylesheet(); // mxStylesheet
-
-        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
-        defaultVertexStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
-
+        // edge
         const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
+        defaultEdgeStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+        defaultEdgeStyle[StyleIdentifiers.STYLE_FONTSIZE] = 12;
         defaultEdgeStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
+        // vertex
+        const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
+        defaultVertexStyle[StyleIdentifiers.STYLE_FONTFAMILY] = 'Courier New,serif';
+        defaultVertexStyle[StyleIdentifiers.STYLE_FONTSIZE] = 12;
+        defaultVertexStyle[StyleIdentifiers.STYLE_FONTSTYLE] = FontStyle.FONT_ITALIC;
     }
-
 }
 
 const bpmnVisualizationCustomDefaultFont = new BpmnVisualizationCustomDefaultFont('bpmn-container-custom-default-font');
 bpmnVisualizationCustomDefaultFont.load(bpmn);
-resetStyleDefault();
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`StyleDefault` is going to be deprecated mainly because it is a global state. Use mxGraph style instead.


Covers https://github.com/process-analytics/bpmn-visualization-js/issues/1993

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/087f29dee42552ae5a4a1fb21912d50402afd203/examples/index.html