### PR TITLE
fix(prediction): fix the computing of the paths in the Prediction demo

### DIFF
--- a/demo/predictions/js/data.js
+++ b/demo/predictions/js/data.js
@@ -21,7 +21,7 @@ class ExecutionData {
     constructor(pathResolver) {
         this._pathResolver = pathResolver;
 
-        this._commonExecutedElements = pathResolver.flatPaths([
+        this._commonExecutedElements = pathResolver.flatPathsWithNextEdges([
             // customer
             '_6-61', // start event
             '_6-74', // select a pizza
@@ -58,7 +58,7 @@ class PredicatedLateExecutionData extends ExecutionData {
         this._executedElements = this._commonExecutedElements;
         this._runningElementWithPrediction = this._vendorBakeThePizzaId;
 
-        this._predictedPaths = pathResolver.flatPaths([
+        this._predictedPaths = pathResolver.flatPathsBetweenShapes([
             // customer elements
             this._customerEvtBasedGwId,
             '_6-219', // timer event
@@ -75,11 +75,11 @@ class PredictedOnTimeExecutionData extends ExecutionData {
     constructor(pathResolver) {
         super(pathResolver)
 
-        this._executedElements = [...this._commonExecutedElements, ...pathResolver.flatPaths([this._vendorBakeThePizzaId])];
+        this._executedElements = [...this._commonExecutedElements, ...pathResolver.flatPathsWithNextEdges([this._vendorBakeThePizzaId])];
 
         this._runningElementWithPrediction = '_6-514'; // vendor 'Deliver the pizza'
 
-        this._predictedPaths =  pathResolver.flatPaths([
+        this._predictedPaths =  pathResolver.flatPathsBetweenShapes([
             // customer elements
             this._customerEvtBasedGwId,
             '_6-202', // msg event 'Pizza received'

--- a/demo/predictions/js/data.js
+++ b/demo/predictions/js/data.js
@@ -20,7 +20,8 @@ class ExecutionData {
 
     constructor(pathResolver) {
         this._pathResolver = pathResolver;
-        this._commonExecutedElements = pathResolver.getVisitedEdges([
+
+        this._commonExecutedElements = pathResolver.flatPaths([
             // customer
             '_6-61', // start event
             '_6-74', // select a pizza
@@ -56,7 +57,8 @@ class PredicatedLateExecutionData extends ExecutionData {
 
         this._executedElements = this._commonExecutedElements;
         this._runningElementWithPrediction = this._vendorBakeThePizzaId;
-        this._predictedPaths = pathResolver.getVisitedEdges([
+
+        this._predictedPaths = pathResolver.flatPaths([
             // customer elements
             this._customerEvtBasedGwId,
             '_6-219', // timer event
@@ -73,9 +75,11 @@ class PredictedOnTimeExecutionData extends ExecutionData {
     constructor(pathResolver) {
         super(pathResolver)
 
-        this._executedElements = pathResolver.getVisitedEdges([...this._commonExecutedElements, this._vendorBakeThePizzaId ]);
+        this._executedElements = [...this._commonExecutedElements, ...pathResolver.flatPaths([this._vendorBakeThePizzaId])];
+
         this._runningElementWithPrediction = '_6-514'; // vendor 'Deliver the pizza'
-        this._predictedPaths = pathResolver.getVisitedEdges([
+
+        this._predictedPaths =  pathResolver.flatPaths([
             // customer elements
             this._customerEvtBasedGwId,
             '_6-202', // msg event 'Pizza received'

--- a/demo/predictions/js/path.js
+++ b/demo/predictions/js/path.js
@@ -32,7 +32,7 @@ class PathResolver {
     }
 
     flatPaths(shapeIds) {
-        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) || shapeIds.includes(path.targetId)).map(path => path.edgeId)];
+        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId)).map(path => path.edgeId)];
     }
 
     #buildPaths(edges) {

--- a/demo/predictions/js/path.js
+++ b/demo/predictions/js/path.js
@@ -31,8 +31,18 @@ class PathResolver {
         this.#paths = this.#buildPaths(bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(Object.values(bpmnvisu.FlowKind)));
     }
 
-    flatPaths(shapeIds) {
-        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId)).map(path => path.edgeId)];
+    /**
+     * @param {string[]} shapeIds
+     */
+    flatPathsBetweenShapes(shapeIds) {
+        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) && shapeIds.includes(path.targetId)).map(path => path.edgeId)];
+    }
+
+    /**
+     * @param {string[]} shapeIds
+     */
+    flatPathsWithNextEdges(shapeIds) {
+        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) ).map(path => path.edgeId)];
     }
 
     #buildPaths(edges) {

--- a/demo/predictions/js/path.js
+++ b/demo/predictions/js/path.js
@@ -1,43 +1,51 @@
-// From Bonita Day 2023 Demo
-class PathResolver {
-    _bpmnVisualization;
+class Path {
+    #sourceId ;
+    #edgeId;
+    #targetId;
 
-    constructor(bpmnVisualization) {
-        this._bpmnVisualization = bpmnVisualization;
+    constructor(sourceId, edgeId, targetId) {
+        this.#sourceId = sourceId;
+        this.#edgeId = edgeId;
+        this.#targetId = targetId;
     }
 
-    getVisitedEdges(shapeIds) {
-        const edgeIds = new Set();
-        for (const shapeId of shapeIds) {
-            const shapeElt = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shapeId)[0];
-            if (!shapeElt) {
-                continue;
-            }
+    get sourceId() {
+        return this.#sourceId;
+    }
 
-            const bpmnSemantic = shapeElt.bpmnSemantic;
-            const incomingEdges = bpmnSemantic.incomingIds;
-            if (incomingEdges) {
-                for (const edgeId of incomingEdges) {
-                    const edgeElement = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-                    const sourceRef = edgeElement.bpmnSemantic.sourceRefId;
-                    if (shapeIds.includes(sourceRef)) {
-                        edgeIds.add(edgeId);
-                    }
-                }
-            }
+    get edgeId() {
+        return this.#edgeId;
+    }
 
-            const outgoingEdges = bpmnSemantic.outgoingIds;
-            if (outgoingEdges) {
-                for (const edgeId of outgoingEdges) {
-                    const edgeElement = this._bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-                    const targetRef = edgeElement.bpmnSemantic.targetRefId;
-                    if (shapeIds.includes(targetRef)) {
-                        edgeIds.add(edgeId);
-                    }
-                }
-            }
+    get targetId() {
+        return this.#targetId;
+    }
+}
+
+// From the Path Demo
+class PathResolver {
+
+    #paths;
+
+    constructor(bpmnVisualization) {
+        this.#paths = this.#buildPaths(bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(Object.values(bpmnvisu.FlowKind)));
+    }
+
+/*    doActionOnPath(filter, actionOnFilteredPath)  {
+        const filteredPaths = this.#paths.filter(path => filter(path));
+        if (filteredPaths.length > 0) {
+            actionOnFilteredPath(filteredPaths[0]);
         }
+    }*/
 
-        return Array.from(edgeIds);
+    flatPaths(shapeIds) {
+        return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) || shapeIds.includes(path.targetId)).map(path => path.edgeId)];
+    }
+
+    #buildPaths(edges) {
+        return edges.map(edge => {
+            const bpmnSemantic = edge.bpmnSemantic;
+            return new Path(bpmnSemantic.sourceRefId, bpmnSemantic.id , bpmnSemantic.targetRefId);
+        });
     }
 }

--- a/demo/predictions/js/path.js
+++ b/demo/predictions/js/path.js
@@ -1,3 +1,4 @@
+// From the Path Demo
 class Path {
     #sourceId ;
     #edgeId;
@@ -22,7 +23,6 @@ class Path {
     }
 }
 
-// From the Path Demo
 class PathResolver {
 
     #paths;
@@ -30,13 +30,6 @@ class PathResolver {
     constructor(bpmnVisualization) {
         this.#paths = this.#buildPaths(bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(Object.values(bpmnvisu.FlowKind)));
     }
-
-/*    doActionOnPath(filter, actionOnFilteredPath)  {
-        const filteredPaths = this.#paths.filter(path => filter(path));
-        if (filteredPaths.length > 0) {
-            actionOnFilteredPath(filteredPaths[0]);
-        }
-    }*/
 
     flatPaths(shapeIds) {
         return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) || shapeIds.includes(path.targetId)).map(path => path.edgeId)];


### PR DESCRIPTION
covers #476

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix_compute_path_in_prediction_demo/demo/predictions/index.html

:warning:  This fix don't use anymore the `PathResolver` of **Bonita Day Demo**.

<table><tbody><tr><td>In the <code>master</code> branch</td><td>With this fix</td></tr><tr><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/c7655360-b819-4c3e-8872-faa92e69f88b" alt=""></figure></td><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/5dfe139e-116e-4c90-b1de-ec611ff0edb3"></figure></td></tr><tr><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/87b8a8b5-2a1b-4107-a7b3-584daa0cdc46" alt=""></figure></td><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/b36b9dcd-84a9-40cc-b8f3-7dc99a688c4b"></figure></td></tr></tbody></table>