### PR TITLE
feat(prediction): make non predicted path less visible

### DIFF
--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -33,10 +33,15 @@
     /* message event icon */
 .bpmn-event-def-message.state-already-executed > rect,
 .bpmn-event-def-message.state-already-executed > path,
-    /* event stroke */
-.bpmn-type-event.state-already-executed > ellipse {
+    /* event */
+.bpmn-type-event.state-already-executed > * {
     filter: blur(2px);
     stroke: var(--color-path-executed);
+}
+
+    /* end event center circle */
+.bpmn-type-event.state-already-executed > ellipse:nth-child(2) {
+    fill: var(--color-path-executed);
 }
 
     /* labels (the selector applies to all div, not the only one that contains text, but this is ok.
@@ -58,19 +63,6 @@
 /* envelope of the message event */
 .bpmn-event-def-message.state-running > rect {
     fill: var(--color-state-running);
-}
-
-/* gateway stroke and icon */
-.bpmn-type-gateway.state-running > *,
-/* event stroke and icon */
-.bpmn-type-event.state-running > * {
-    stroke: black;
-}
-
-/* labels (the selector applies to all div, not the only one that contains text, but this is ok.
- Use important to override the color set inline in the style attribute of the label div */
-.bpmn-label.state-running > g div {
-    color: black !important;
 }
 
 /*apply shadow on hover*/

--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -9,6 +9,10 @@
     --stroke-path-predicted: 0.18rem;
 }
 
+/* ================================================================================================================== */
+/* ALREADY EXECUTED */
+/* ================================================================================================================== */
+
     /* parallel gateway icon */
 .bpmn-parallel-gateway.state-already-executed > path:nth-child(2),
     /* message flow arrow */
@@ -43,6 +47,7 @@
     filter: blur(1px);
 }
 
+
 /* ================================================================================================================== */
 /* INFO */
 /* ================================================================================================================== */
@@ -53,6 +58,19 @@
 /* envelope of the message event */
 .bpmn-event-def-message.state-running > rect {
     fill: var(--color-state-running);
+}
+
+/* gateway stroke and icon */
+.bpmn-type-gateway.state-running > *,
+/* event stroke and icon */
+.bpmn-type-event.state-running > * {
+    stroke: black;
+}
+
+/* labels (the selector applies to all div, not the only one that contains text, but this is ok.
+ Use important to override the color set inline in the style attribute of the label div */
+.bpmn-label.state-running > g div {
+    color: black !important;
 }
 
 /*apply shadow on hover*/
@@ -170,3 +188,4 @@
     color: var(--color-path-predicted-on-time) !important;
     font-weight: bold;
 }
+

--- a/demo/predictions/js/data.js
+++ b/demo/predictions/js/data.js
@@ -74,7 +74,7 @@ class PredicatedLateExecutionData extends ExecutionData {
             '_6-695', // 'Calm customer'
         ]);
 
-        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction];
+        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction, ...this._predictedPaths];
         this._nonPredictedElements = pathResolver.flatAllPaths().filter(id=> !allCustomizedElements.includes(id));
     }
 }
@@ -97,7 +97,7 @@ class PredictedOnTimeExecutionData extends ExecutionData {
             '_6-565', // 'Receive payment'
         ]);
 
-        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction];
+        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction, ...this._predictedPaths];
         this._nonPredictedElements = pathResolver.flatAllPaths().filter(id=> !allCustomizedElements.includes(id));
     }
 

--- a/demo/predictions/js/data.js
+++ b/demo/predictions/js/data.js
@@ -10,11 +10,13 @@ class ExecutionData {
 
     _executedElements;
 
+    _nonPredictedElements;
+
     _runningElementWithPrediction;
 
     _predictedPaths;
 
-    #runningElementsWithoutPrediction = [this._vendorWhereIsMyPizzaId, this._customerEvtBasedGwId];
+    _runningElementsWithoutPrediction = [this._vendorWhereIsMyPizzaId, this._customerEvtBasedGwId];
 
     _pathResolver;
 
@@ -41,12 +43,16 @@ class ExecutionData {
         return this._runningElementWithPrediction;
     }
 
+    get runningElementsWithoutPrediction() {
+        return this._runningElementsWithoutPrediction;
+    }
+
     get predictedPaths() {
         return this._predictedPaths;
     }
 
-    get runningElementsWithoutPrediction() {
-        return this.#runningElementsWithoutPrediction;
+    get nonPredictedElements() {
+        return this._nonPredictedElements;
     }
 }
 
@@ -67,6 +73,9 @@ class PredicatedLateExecutionData extends ExecutionData {
             this._vendorWhereIsMyPizzaId,
             '_6-695', // 'Calm customer'
         ]);
+
+        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction];
+        this._nonPredictedElements = pathResolver.flatAllPaths().filter(id=> !allCustomizedElements.includes(id));
     }
 }
 
@@ -87,6 +96,9 @@ class PredictedOnTimeExecutionData extends ExecutionData {
             // vendor elements
             '_6-565', // 'Receive payment'
         ]);
+
+        const allCustomizedElements = [...this._executedElements, this._runningElementWithPrediction];
+        this._nonPredictedElements = pathResolver.flatAllPaths().filter(id=> !allCustomizedElements.includes(id));
     }
 
 }

--- a/demo/predictions/js/path.js
+++ b/demo/predictions/js/path.js
@@ -45,6 +45,18 @@ class PathResolver {
         return [...shapeIds, ...this.#paths.filter(path => shapeIds.includes(path.sourceId) ).map(path => path.edgeId)];
     }
 
+    flatAllPaths(){
+        const flatPaths = new Set();
+
+        for (const path of this.#paths) {
+            flatPaths.add(path.edgeId);
+            flatPaths.add(path.sourceId);
+            flatPaths.add(path.targetId);
+        }
+
+        return Array.from(flatPaths);
+    }
+    
     #buildPaths(edges) {
         return edges.map(edge => {
             const bpmnSemantic = edge.bpmnSemantic;

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -11,7 +11,6 @@ class PredicatedLateUseCase extends UseCase {
         this._initManagers();
 
         this._style.reduceVisibilityOfExecutedElements(this._executionData.executedElements);
-        this._style.reduceVisibilityOfNonPredictedElements(this._executionData.nonPredictedElements);
         this._style.highlightRunningElementsWithPrediction(this._executionData.runningElementWithPrediction);
         this._style.toggleHighlightRunningElementsWithoutPrediction(this._executionData.runningElementsWithoutPrediction);
         this._registerInteractions(this._executionData.predictedPaths, this._executionData.runningElementsWithoutPrediction, this._executionData.runningElementWithPrediction);
@@ -30,6 +29,7 @@ class PredicatedLateUseCase extends UseCase {
         const highlightPredictedPath = () => {
             this._style.toggleHighlightRunningElementsWithoutPrediction(runningElementsWithoutPrediction);
             this._style.toggleHighlightPredictedPath(predictedPath);
+            this._style.toggleReduceVisibilityOfNonPredictedElements(this._executionData.nonPredictedElements);
         }
 
         elementTogglingPath.htmlElement.addEventListener('mouseenter', highlightPredictedPath);

--- a/demo/predictions/js/prediction-use-case.js
+++ b/demo/predictions/js/prediction-use-case.js
@@ -11,6 +11,7 @@ class PredicatedLateUseCase extends UseCase {
         this._initManagers();
 
         this._style.reduceVisibilityOfExecutedElements(this._executionData.executedElements);
+        this._style.reduceVisibilityOfNonPredictedElements(this._executionData.nonPredictedElements);
         this._style.highlightRunningElementsWithPrediction(this._executionData.runningElementWithPrediction);
         this._style.toggleHighlightRunningElementsWithoutPrediction(this._executionData.runningElementsWithoutPrediction);
         this._registerInteractions(this._executionData.predictedPaths, this._executionData.runningElementsWithoutPrediction, this._executionData.runningElementWithPrediction);

--- a/demo/predictions/js/style.js
+++ b/demo/predictions/js/style.js
@@ -17,7 +17,7 @@ class Style {
      * @param {string[]} ids
      */
     reduceVisibilityOfNonPredictedElements(ids) {
-        const styleColor = { color:'gray' };
+        const styleColor = { color: '#636363' };
         this._bpmnElementsRegistry.updateStyle(ids, { font: styleColor, stroke: styleColor })
     }
 

--- a/demo/predictions/js/style.js
+++ b/demo/predictions/js/style.js
@@ -16,9 +16,8 @@ class Style {
     /**
      * @param {string[]} ids
      */
-    reduceVisibilityOfNonPredictedElements(ids) {
-        const styleColor = { color: '#636363' };
-        this._bpmnElementsRegistry.updateStyle(ids, { font: styleColor, stroke: styleColor })
+    toggleReduceVisibilityOfNonPredictedElements(ids) {
+        this._bpmnElementsRegistry.toggleCssClasses(ids, 'state-already-executed');
     }
 
     /**

--- a/demo/predictions/js/style.js
+++ b/demo/predictions/js/style.js
@@ -16,6 +16,14 @@ class Style {
     /**
      * @param {string[]} ids
      */
+    reduceVisibilityOfNonPredictedElements(ids) {
+        const styleColor = { color:'gray' };
+        this._bpmnElementsRegistry.updateStyle(ids, { font: styleColor, stroke: styleColor })
+    }
+
+    /**
+     * @param {string[]} ids
+     */
     toggleHighlightRunningElementsWithoutPrediction(ids) {
         this._bpmnElementsRegistry.toggleCssClasses(ids, 'state-running');
     }


### PR DESCRIPTION
**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/260-make_non_predicted_path_less_visible/demo/predictions/index.html


![image](https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/c9071828-f052-4c9a-93b4-7119b8673602)
![image](https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/8bc49a6b-c609-49f7-a59f-7c8d2698bbf7)

Covers #260 