### PR TITLE
feat(prediction): restore message flow icons in the BPMN diagram

### DIFF
--- a/demo/predictions/css/demo.css
+++ b/demo/predictions/css/demo.css
@@ -24,6 +24,8 @@
 
     /* message flow start marker */
 .bpmn-message-flow.state-already-executed > ellipse,
+    /* message flow icon */
+.bpmn-message-flow-icon.state-already-executed > * ,
     /* sequence/message flow line and arrow (end marker) */
 .bpmn-type-flow.state-already-executed > path,
     /* task */
@@ -150,6 +152,11 @@
     /* sequence flow arrow */
 .bpmn-sequence-flow.path-predicted-on-time > path:nth-child(3) {
     fill: var(--color-path-predicted-on-time);
+}
+
+/* message flow icon */
+.bpmn-message-flow-icon.path-predicted-on-time > * {
+    stroke: var(--color-path-predicted-on-time);
 }
 
 .bpmn-type-gateway.path-predicted-on-time > path:nth-child(1),

--- a/examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js
+++ b/examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js
@@ -343,7 +343,7 @@ function pizzaDiagram() {
         <dc:Bounds x="791" y="668" width="83" height="68" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-638" bpmnElement="_6-638">
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-638" bpmnElement="_6-638" messageVisibleKind="initiating">
         <di:waypoint x="476" y="177" />
         <di:waypoint x="476" y="302" />
         <di:waypoint x="264" y="302" />
@@ -359,21 +359,21 @@ function pizzaDiagram() {
         <di:waypoint x="510" y="454" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-646" bpmnElement="_6-646">
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-646" bpmnElement="_6-646" messageVisibleKind="initiating">
         <di:waypoint x="963" y="668" />
         <di:waypoint x="963" y="228" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="973" y="446" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-648" bpmnElement="_6-648">
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-648" bpmnElement="_6-648" messageVisibleKind="initiating">
         <di:waypoint x="924" y="228" />
         <di:waypoint x="924" y="668" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="883" y="446" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640">
+      <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640" messageVisibleKind="initiating">
         <di:waypoint x="833" y="668" />
         <di:waypoint x="833" y="210" />
         <bpmndi:BPMNLabel>

--- a/examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js
+++ b/examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js
@@ -363,14 +363,14 @@ function pizzaDiagram() {
         <di:waypoint x="963" y="668" />
         <di:waypoint x="963" y="228" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="973" y="446" width="34" height="14" />
+          <dc:Bounds x="973" y="470" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-648" bpmnElement="_6-648" messageVisibleKind="initiating">
         <di:waypoint x="924" y="228" />
         <di:waypoint x="924" y="668" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="883" y="446" width="34" height="14" />
+          <dc:Bounds x="883" y="470" width="34" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Trisotech.Visio__6__6-640" bpmnElement="_6-640" messageVisibleKind="initiating">


### PR DESCRIPTION
**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/260-Restore_message_flow_icons_in_the_BPMN_diagram_once/demo/predictions/index.html

![image](https://github.com/process-analytics/bpmn-visualization-examples/assets/4921914/a47f7fbd-d474-408a-b524-ea01f0500981)

Depends on #523

Covers #260