### PR TITLE
refactor(vue-demo): use `bv-experimental-add-ons`

### DIFF
--- a/projects/typescript-vue/package.json
+++ b/projects/typescript-vue/package.json
@@ -1,6 +1,5 @@
 {
   "name": "bpmn-visualization-ts-vue",
-  "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -9,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@process-analytics/bv-experimental-add-ons": "0.2.0",
     "bpmn-visualization": "0.37.0",
     "spectre.css": "^0.5.9",
     "vue": "^3.3.4"

--- a/projects/typescript-vue/src/app.vue
+++ b/projects/typescript-vue/src/app.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { BpmnElement, BpmnElementsRegistry, BpmnVisualization, FitType, OverlayPosition, ShapeUtil } from 'bpmn-visualization';
+import { BpmnElement, BpmnElementsRegistry, BpmnVisualization, FitType, OverlayPosition } from 'bpmn-visualization';
+import { ShapeUtil } from '@process-analytics/bv-experimental-add-ons';
 import pizzaDiagram from "./pizza-collaboration.bpmn?raw"
-import { isBpmnArtifact } from './bpmn-utils';
 
 
 let vis: BpmnVisualization;
@@ -38,7 +38,7 @@ onMounted(async () => {
 })
 
 function getAllFlowNodes(): BpmnElement[] {
-    return registry.getElementsByKinds(ShapeUtil.flowNodeKinds().filter(kind => !isBpmnArtifact(kind)));
+    return registry.getElementsByKinds(ShapeUtil.flowNodeKinds().filter(kind => !ShapeUtil.isBpmnArtifact(kind)));
 }
 
 function setupEventHandlers() {

--- a/projects/typescript-vue/src/bpmn-utils.ts
+++ b/projects/typescript-vue/src/bpmn-utils.ts
@@ -1,6 +1,0 @@
-import { ShapeBpmnElementKind } from 'bpmn-visualization';
-
-export const isBpmnArtifact = (kind: ShapeBpmnElementKind): boolean => {
-  // may be directly available in bpmn-visualization in the future
-  return kind === ShapeBpmnElementKind.GROUP || kind === ShapeBpmnElementKind.TEXT_ANNOTATION ;
-};


### PR DESCRIPTION
Use the new `ShapeUtil.isBpmnArtifact` method instead of the custom implementation stored in the demo.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/6c79e20f05e65d6b64b4aa9f19d6779e12481f5c/examples/index.html