### PR TITLE
feat: use resource integrity when loading bpmn-visualization from CDN

### DIFF
--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get the bpmn-visualization npm package
         run: |
-          curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-{{env.VERSION}}.tgz -o bpmn-visualization.tgz
+          curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
           tar -xvzf bpmn-visualization.tgz
           ll -lh
       - name: Compute IIFE bundle integrity

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -54,18 +54,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update bpmn-visualization version in all examples
         run: ./scripts/update-lib-version.bash ${{ env.VERSION }} ${{ env.IIFE_BUNDLE_INTEGRITY }}
-# TODO restore when tests have been completed
-#      - name: Delete old Load and Navigation demo
-#        run: rm -rf demo/load-and-navigation
-#      - name: Download Load and Navigation demo ${{ env.VERSION }}
-#        uses: dawidd6/action-download-artifact@v2
-#        with:
-#          github_token: ${{ secrets.GH_RELEASE_TOKEN }}
-#          repo: ${{ env.BUILD_DEMO_REPO }}
-#          workflow: ${{ env.BUILD_DEMO_WORKFLOW_ID }}
-#          workflow_conclusion: success
-#          name: ${{ env.ARTIFACT_NAME }}
-#          path: demo/load-and-navigation
+      - name: Delete old Load and Navigation demo
+        run: rm -rf demo/load-and-navigation
+      - name: Download Load and Navigation demo ${{ env.VERSION }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GH_RELEASE_TOKEN }}
+          repo: ${{ env.BUILD_DEMO_REPO }}
+          workflow: ${{ env.BUILD_DEMO_WORKFLOW_ID }}
+          workflow_conclusion: success
+          name: ${{ env.ARTIFACT_NAME }}
+          path: demo/load-and-navigation
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.2
         with:

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           export PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
           echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
+          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM" >> "$GITHUB_ENV"
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -54,17 +54,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update bpmn-visualization version in all examples
         run: ./scripts/update-lib-version.bash ${{ env.VERSION }} ${{ env.IIFE_BUNDLE_INTEGRITY }}
-      - name: Delete old Load and Navigation demo
-        run: rm -rf demo/load-and-navigation
-      - name: Download Load and Navigation demo ${{ env.VERSION }}
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          repo: ${{ env.BUILD_DEMO_REPO }}
-          workflow: ${{ env.BUILD_DEMO_WORKFLOW_ID }}
-          workflow_conclusion: success
-          name: ${{ env.ARTIFACT_NAME }}
-          path: demo/load-and-navigation
+# TODO restore when tests have been completed
+#      - name: Delete old Load and Navigation demo
+#        run: rm -rf demo/load-and-navigation
+#      - name: Download Load and Navigation demo ${{ env.VERSION }}
+#        uses: dawidd6/action-download-artifact@v2
+#        with:
+#          github_token: ${{ secrets.GH_RELEASE_TOKEN }}
+#          repo: ${{ env.BUILD_DEMO_REPO }}
+#          workflow: ${{ env.BUILD_DEMO_WORKFLOW_ID }}
+#          workflow_conclusion: success
+#          name: ${{ env.ARTIFACT_NAME }}
+#          path: demo/load-and-navigation
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.2
         with:

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -28,11 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get the bpmn-visualization npm package
-        run: curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-{{env.VERSION}}.tgz -o bpmn-visualization.tgz
-  # untar
-  # compute integrity
+        run: |
+          curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-{{env.VERSION}}.tgz -o bpmn-visualization.tgz
+          tar -xvzf bpmn-visualization.tgz
+          ll -lh
+      - name: Compute IIFE bundle integrity
+        run: echo "sha384-$(cat ./package/dist/bpmn-visualization.min.js | openssl dgst -sha384 -binary | openssl base64 -A)"
   # store in output
-
+# test output retrieval in another job
   update-version:
     runs-on: ubuntu-22.04
     needs: compute-iife-bundle-integrity

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -28,14 +28,12 @@ jobs:
     outputs:
       integrity-value: ${{ steps.compute-integrity.outputs.value }}
     steps:
-      # TODO try to verify the npm package checksum
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
           PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
           echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
           tar -xvzf bpmn-visualization.tgz
-          ls -lh
       - name: Compute IIFE bundle integrity
         id: 'compute-integrity'
         run: |

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -28,11 +28,12 @@ jobs:
     steps:
       - name: Get the checksum of the bpmn-visualization npm package
         run: |
-          export PACKAGE_INTEGRITY=echo "$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)"
-          echo "PACKAGE_INTEGRITY=$PACKAGE_INTEGRITY"
+          export PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
+          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
+          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
           tar -xvzf bpmn-visualization.tgz
           ls -lh
       - name: Compute IIFE bundle integrity

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
           tar -xvzf bpmn-visualization.tgz
-          ll -lh
+          ls -lh
       - name: Compute IIFE bundle integrity
         run: echo "sha384-$(cat ./package/dist/bpmn-visualization.min.js | openssl dgst -sha384 -binary | openssl base64 -A)"
   # store in output

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
+    outputs:
+      integrity-value: ${{ steps.compute-integrity.outputs.value }}
     steps:
 #      - name: Get the checksum of the bpmn-visualization npm package
 #        run: |
@@ -39,9 +41,23 @@ jobs:
           tar -xvzf bpmn-visualization.tgz
           ls -lh
       - name: Compute IIFE bundle integrity
-        run: echo "sha384-$(cat ./package/dist/bpmn-visualization.min.js | openssl dgst -sha384 -binary | openssl base64 -A)"
-  # store in output
-# test output retrieval in another job
+        id: 'compute-integrity'
+        run: |
+          integrity="sha384-$(cat ./package/dist/bpmn-visualization.min.js | openssl dgst -sha384 -binary | openssl base64 -A)"
+          echo "integrity=$integrity"
+          echo "value=$integrity" >> "$GITHUB_OUTPUT"
+
+# TODO only to test output retrieval from another job - remove when validated
+  check-computed-integrity:
+    runs-on: ubuntu-22.04
+    needs: compute-iife-bundle-integrity
+    steps:
+      - name: Log output from previous job
+        env:
+          IIFE-BUNDLE-INTEGRITY: ${{needs.compute-iife-bundle-integrity.outputs.integrity-value}}
+        run: |
+          echo "IIFE-BUNDLE-INTEGRITY from previous job: $IIFE-BUNDLE-INTEGRITY"
+
   update-version:
     runs-on: ubuntu-22.04
     needs: compute-iife-bundle-integrity

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
     steps:
+      - name: Get the checksum of the bpmn-visualization npm package
+        run: |
+          export PACKAGE_INTEGRITY=echo "$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)"
+          echo "PACKAGE_INTEGRITY=$PACKAGE_INTEGRITY"
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -41,22 +41,9 @@ jobs:
           echo "integrity=$integrity"
           echo "value=$integrity" >> "$GITHUB_OUTPUT"
 
-# TODO only to test output retrieval from another job - remove when validated
-  check-computed-integrity:
-    runs-on: ubuntu-22.04
-    needs: compute-iife-bundle-integrity
-    steps:
-      - name: Log output from previous job
-        env:
-          IIFE_BUNDLE_INTEGRITY: ${{needs.compute-iife-bundle-integrity.outputs.integrity-value}}
-        run: |
-          echo "IIFE_BUNDLE_INTEGRITY from previous job: $IIFE_BUNDLE_INTEGRITY"
-
   update-version:
     runs-on: ubuntu-22.04
     needs: compute-iife-bundle-integrity
-    ### TODO temp disable - remove
-    if: github.event_name == 'pull_request'
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
       ARTIFACT_NAME: ${{ github.event.client_payload.artifact_name || github.event.inputs.artifact_name }}

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
     steps:
-      - uses: actions/checkout@v4
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -54,9 +54,9 @@ jobs:
     steps:
       - name: Log output from previous job
         env:
-          IIFE-BUNDLE-INTEGRITY: ${{needs.compute-iife-bundle-integrity.outputs.integrity-value}}
+          IIFE_BUNDLE_INTEGRITY: ${{needs.compute-iife-bundle-integrity.outputs.integrity-value}}
         run: |
-          echo "IIFE-BUNDLE-INTEGRITY from previous job: $IIFE-BUNDLE-INTEGRITY"
+          echo "IIFE_BUNDLE_INTEGRITY from previous job: $IIFE_BUNDLE_INTEGRITY"
 
   update-version:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -26,14 +26,15 @@ jobs:
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
     steps:
-      - name: Get the checksum of the bpmn-visualization npm package
-        run: |
-          export PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
-          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
-          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM" >> "$GITHUB_ENV"
+#      - name: Get the checksum of the bpmn-visualization npm package
+#        run: |
+#          export PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
+#          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
+#          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM" >> "$GITHUB_ENV"
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
+          PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
           echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
           tar -xvzf bpmn-visualization.tgz
           ls -lh

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -21,8 +21,23 @@ on:
         required: true
 
 jobs:
-  updateVersion:
+  compute-iife-bundle-integrity:
     runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the bpmn-visualization npm package
+        run: curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-{{env.VERSION}}.tgz -o bpmn-visualization.tgz
+  # untar
+  # compute integrity
+  # store in output
+
+  update-version:
+    runs-on: ubuntu-22.04
+    needs: compute-iife-bundle-integrity
+    ### TODO temp disable - remove
+    if: github.event_name == 'pull_request'
     env:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
       ARTIFACT_NAME: ${{ github.event.client_payload.artifact_name || github.event.inputs.artifact_name }}

--- a/.github/workflows/update_bpmn_visualization_version.yml
+++ b/.github/workflows/update_bpmn_visualization_version.yml
@@ -28,11 +28,7 @@ jobs:
     outputs:
       integrity-value: ${{ steps.compute-integrity.outputs.value }}
     steps:
-#      - name: Get the checksum of the bpmn-visualization npm package
-#        run: |
-#          export PACKAGE_CHECKSUM=$(npm view bpmn-visualization@${{ env.VERSION }} dist.integrity)
-#          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM"
-#          echo "PACKAGE_CHECKSUM=$PACKAGE_CHECKSUM" >> "$GITHUB_ENV"
+      # TODO try to verify the npm package checksum
       - name: Get the bpmn-visualization npm package
         run: |
           curl https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-${{ env.VERSION }}.tgz -o bpmn-visualization.tgz
@@ -68,10 +64,11 @@ jobs:
       ARTIFACT_NAME: ${{ github.event.client_payload.artifact_name || github.event.inputs.artifact_name }}
       BUILD_DEMO_WORKFLOW_ID: ${{ github.event.client_payload.build_demo_workflow_id || github.event.inputs.build_demo_workflow_id }}
       BUILD_DEMO_REPO: ${{ github.event.client_payload.build_demo_repo || github.event.inputs.build_demo_repo }}
+      IIFE_BUNDLE_INTEGRITY: ${{needs.compute-iife-bundle-integrity.outputs.integrity-value}}
     steps:
       - uses: actions/checkout@v4
       - name: Update bpmn-visualization version in all examples
-        run: ./scripts/update-lib-version.bash ${{ env.VERSION }}
+        run: ./scripts/update-lib-version.bash ${{ env.VERSION }} ${{ env.IIFE_BUNDLE_INTEGRITY }}
       - name: Delete old Load and Navigation demo
         run: rm -rf demo/load-and-navigation
       - name: Download Load and Navigation demo ${{ env.VERSION }}

--- a/demo/draw-path/index.html
+++ b/demo/draw-path/index.html
@@ -26,7 +26,7 @@ limitations under the License.
     <link rel="stylesheet" href="./css/step.css" type="text/css">
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
             crossorigin="anonymous"></script>
     <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>

--- a/demo/hacktoberfest-custom-themes/index.html
+++ b/demo/hacktoberfest-custom-themes/index.html
@@ -35,7 +35,7 @@ limitations under the License.
     </style>
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <!-- load the example -->
     <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../../examples/static/js/style-identifiers.js"></script>

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -24,7 +24,7 @@ limitations under the License.
     <link rel="stylesheet" href="./css/legend.css" type="text/css">
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
             crossorigin="anonymous"></script>
     <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>

--- a/demo/prediction/index.html
+++ b/demo/prediction/index.html
@@ -30,7 +30,7 @@ limitations under the License.
 
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="../../examples/static/js/diagram/bpmn-diagram-bpmn-spec-pizza.js"></script>
     <script defer src="../static/js/use-case.js"></script>
     <script defer src="./js/path.js"></script>

--- a/examples/custom-behavior/apply-css-classes/index.html
+++ b/examples/custom-behavior/apply-css-classes/index.html
@@ -86,7 +86,7 @@ limitations under the License.
         }
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
     <script defer src="index.js"></script>
 </head>

--- a/examples/custom-behavior/call-activity-with-modal-on-mouse-over/index.html
+++ b/examples/custom-behavior/call-activity-with-modal-on-mouse-over/index.html
@@ -34,7 +34,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
         <script defer src="./modal.js"></script>

--- a/examples/custom-behavior/call-activity-with-reload-on-dblclick/index.html
+++ b/examples/custom-behavior/call-activity-with-reload-on-dblclick/index.html
@@ -36,7 +36,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
         <script defer src="./breadcrumbs.js"></script>

--- a/examples/custom-behavior/call-activity-with-tabs-on-click/index.html
+++ b/examples/custom-behavior/call-activity-with-tabs-on-click/index.html
@@ -36,7 +36,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
     </head>

--- a/examples/custom-behavior/growing-sequence-flow/index.html
+++ b/examples/custom-behavior/growing-sequence-flow/index.html
@@ -57,7 +57,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
     </head>

--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.html
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.html
@@ -50,7 +50,7 @@ limitations under the License.
 
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="index.js"></script>
     </head>

--- a/examples/custom-behavior/running-dashed-message-flow/index.html
+++ b/examples/custom-behavior/running-dashed-message-flow/index.html
@@ -57,7 +57,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
     </head>

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -55,7 +55,7 @@ limitations under the License.
         }
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-a_4_1.js"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_0.js"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>

--- a/examples/custom-bpmn-theme/custom-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-colors/index.html
@@ -22,7 +22,7 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../../static/js/style-identifiers.js"></script>

--- a/examples/custom-bpmn-theme/custom-edge-marker-colors/index.html
+++ b/examples/custom-bpmn-theme/custom-edge-marker-colors/index.html
@@ -36,7 +36,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="../../static/js/style-identifiers.js"></script>
         <script defer src="./index.js"></script>

--- a/examples/custom-bpmn-theme/custom-fonts/index.html
+++ b/examples/custom-bpmn-theme/custom-fonts/index.html
@@ -22,7 +22,7 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../../static/js/style-identifiers.js"></script>

--- a/examples/custom-bpmn-theme/custom-user-task-icon/index.html
+++ b/examples/custom-bpmn-theme/custom-user-task-icon/index.html
@@ -22,7 +22,7 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="index.js"></script>

--- a/examples/diagram-navigation/diagram-fit-after-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-after-load/index.html
@@ -53,7 +53,7 @@ limitations under the License.
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="index.js"></script>
 </head>

--- a/examples/diagram-navigation/diagram-fit-on-load/index.html
+++ b/examples/diagram-navigation/diagram-fit-on-load/index.html
@@ -40,7 +40,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="index.js"></script>
     </head>

--- a/examples/diagram-navigation/diagram-navigation/index.html
+++ b/examples/diagram-navigation/diagram-navigation/index.html
@@ -34,7 +34,7 @@ limitations under the License.
         }
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="./index.js"></script>
 </head>

--- a/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html
@@ -50,7 +50,7 @@ limitations under the License.
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="index.js"></script>
 </head>
 <body>

--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html
@@ -60,7 +60,7 @@ limitations under the License.
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <script defer src="index.js"></script>
 </head>
 <body>

--- a/examples/display-bpmn-diagram/pools-filter-on-load/index.html
+++ b/examples/display-bpmn-diagram/pools-filter-on-load/index.html
@@ -34,7 +34,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagram-pools-filter.js"></script>
         <script defer src="index.js"></script>
     </head>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -59,7 +59,7 @@ limitations under the License.
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
   <script  defer src="https://cdn.jsdelivr.net/npm/bpmn-js@13.0.4/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-ir1JRKKdwrP2SbqZzwTL1j8LF1NBwlEwm49sUEsYxTg=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
   <script defer src="shared.js"></script>
   <script defer src="index.js"></script>
 </head>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -59,7 +59,7 @@ limitations under the License.
   <!-- load bpmn kie-editors-standalone -->
   <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.28.0/dist/bpmn/index.js" integrity="sha256-axAhGJVTnpft43YZxo/HDX7yK8GH5fMQhCfkQLGXr9w=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>
   <script defer src="index.js"></script>
 </head>

--- a/examples/overlays/add-remove/index.html
+++ b/examples/overlays/add-remove/index.html
@@ -48,7 +48,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
     </head>

--- a/examples/overlays/add-stylized/index.html
+++ b/examples/overlays/add-stylized/index.html
@@ -43,7 +43,7 @@ limitations under the License.
         </style>
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->
-        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
         <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
         <script defer src="./index.js"></script>
     </head>

--- a/examples/overlays/custom-overlay-default-style/index.html
+++ b/examples/overlays/custom-overlay-default-style/index.html
@@ -29,7 +29,7 @@ limitations under the License.
     </style>
     <script defer src="../../static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
-    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
     <!-- load the example -->
     <script defer src="../../static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../../static/js/style-defaults.js"></script>

--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -37,7 +37,7 @@ function replaceVersion() {
 # update all html files in the examples folder
 ############################################################
 if [ $# -ne 2 ]; then
-	echo "At least one mandatory parameter is missing missing."
+	echo "At least one mandatory parameter is missing."
 	echo "Parameters order: <new_version> <integrity>"
 	exit 1
 fi

--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -36,12 +36,14 @@ function replaceVersion() {
 ############################################################
 # update all html files in the examples folder
 ############################################################
-if [ $# -ne 1 ]; then
-	echo "Mandatory parameter <new_version> missing."
+if [ $# -ne 2 ]; then
+	echo "At least one mandatory parameter is missing missing."
+	echo "Parameters order: <new_version> <integrity>"
 	exit 1
 fi
 NEW_VERSION=$1
-echo "Updating examples to make them use bpmn-visualization@$NEW_VERSION"
+INTEGRITY=$2
+echo "Updating examples to make them use bpmn-visualization@$NEW_VERSION with integrity: $INTEGRITY"
 
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -8,7 +8,7 @@ function replaceVersion() {
 
   rexep_npm="s/\"bpmn-visualization\": \".*\"/\"bpmn-visualization\": \"$NEW_VERSION\"/"
   # lines to update contains substring like "bpmn-visualization@x.y.z/bpmn-visualization.min.js" integrity="xxxxx"
-  rexep_others="s/\/bpmn-visualization@.*\/dist\/bpmn-visualization.min.js\" integrity=\".*\"/\/bpmn-visualization@$NEW_VERSION\/dist\/bpmn-visualization.min.js\" integrity=\"$INTEGRITY\"/"
+  rexep_others="s/\/bpmn-visualization@.*\/dist\/bpmn-visualization.min.js\" integrity=\".*\"/\/bpmn-visualization@$NEW_VERSION\/dist\/bpmn-visualization.min.js\" integrity=\"$ESCAPED_INTEGRITY\"/"
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ $directory == *demo ]]; then
@@ -44,6 +44,9 @@ fi
 NEW_VERSION=$1
 INTEGRITY=$2
 echo "Updating examples to make them use bpmn-visualization@$NEW_VERSION with integrity: $INTEGRITY"
+
+ESCAPED_INTEGRITY=$(echo "$INTEGRITY" | sed 's;/;\\/;g')
+echo "ESCAPED_INTEGRITY for usage in regex: $ESCAPED_INTEGRITY"
 
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -7,8 +7,8 @@ function replaceVersion() {
   echo "Search for files in $(pwd)"
 
   rexep_npm="s/\"bpmn-visualization\": \".*\"/\"bpmn-visualization\": \"$NEW_VERSION\"/"
-  # lines to update contains substring like "bpmn-visualization@x.y.z"
-  rexep_others="s/\/bpmn-visualization@.*\/dist/\/bpmn-visualization@$NEW_VERSION\/dist/"
+  # lines to update contains substring like "bpmn-visualization@x.y.z/bpmn-visualization.min.js" integrity="xxxxx"
+  rexep_others="s/\/bpmn-visualization@.*\/dist\/bpmn-visualization.min.js\" integrity=\".*\"/\/bpmn-visualization@$NEW_VERSION\/dist\/bpmn-visualization.min.js\" integrity=\"$INTEGRITY\"/"
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ $directory == *demo ]]; then

--- a/scripts/update-lib-version.bash
+++ b/scripts/update-lib-version.bash
@@ -7,8 +7,8 @@ function replaceVersion() {
   echo "Search for files in $(pwd)"
 
   rexep_npm="s/\"bpmn-visualization\": \".*\"/\"bpmn-visualization\": \"$NEW_VERSION\"/"
-  # lines to update contains substring like "bpmn-visualization@x.y.z/bpmn-visualization.min.js" integrity="xxxxx"
-  rexep_others="s/\/bpmn-visualization@.*\/dist\/bpmn-visualization.min.js\" integrity=\".*\"/\/bpmn-visualization@$NEW_VERSION\/dist\/bpmn-visualization.min.js\" integrity=\"$ESCAPED_INTEGRITY\"/"
+  # lines to update contains substring like "bpmn-visualization@x.y.z/dist/bpmn-visualization.min.js" integrity="xxxxx" crossorigin
+  rexep_others="s/\/bpmn-visualization@.*\/dist\/bpmn-visualization.min.js\" integrity=\".*\" crossorigin/\/bpmn-visualization@$NEW_VERSION\/dist\/bpmn-visualization.min.js\" integrity=\"$ESCAPED_INTEGRITY\" crossorigin/"
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ $directory == *demo ]]; then


### PR DESCRIPTION
Previously, we load the `bpmn-visualization` IIFE bundle from the `jsdelivr` CDN without integrity. This was not consistent with the rest of resources that we load from this CDN and this could lead to safety risks.
The version of `bpmn-visualization` is updated automatically when a new release is available. Changing the version is easy, but the integrity computation requires more work. As a first implementation, we decided to not do it.

Now, the integrity string is first computed from the bundle of the npm package (the package is downloaded by the GitHub workflow). Then, all pages using the bundle from the jsdelivr CDN are updated with the new version (as before) and with the new integrity string.
All pages have been updated to use the `bpmn-visualization` 0.39.0 integrity value in order to benefit from the improvement without waiting for the new version.

### Live environment of examples

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/71365fa/examples/index.html

<!--
https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/refactor/use_resource_integrity_for_bpmn-visu/examples/index.html
-->

### Tests

I tested the script with command locally on Ubuntu 20.04:
- `./scripts/update-lib-version.bash 0.39.0 sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ` --> no change
- `./scripts/update-lib-version.bash 0.38.0 sha384-K2Sz6i2iSMe18FznqMMiRexBzPN/nlxor5+/M2L3FwJBlThg/jcYMvkjKvqRC5uQ` --> changes, the page correctly use the 0.38.0 version and the integrity is verified

I cannot test on Windows or macOS, so please fix the syntax if you find issues. Remember that this script is almost never used locally but mainly in a GitHub workflow running on Ubuntu 22. So this is clearly not a priority to make it work on other OS.

Also tested with GitHub actions with a modified workflow that doesn't update the lib demo (not require for the test and make the workflow run easier to configure) - see 5d4399d:
- update to use version0.38.0
  - GH Action run: https://github.com/process-analytics/bpmn-visualization-examples/actions/runs/6123353762
  - created PR: #542
- update to use version 0.37.0
  - GH Action run: https://github.com/process-analytics/bpmn-visualization-examples/actions/runs/6123412047
  - created PR: #543



### Notes

I tried to validate the npm package checksum but I didn't find a solution to use the value returned by `npm view`
```bash
$ npm view bpmn-visualization@0.39.0 dist.integrity
sha512-VX974CN07dVJ8I0d6iWusH87ePZoyTn06me6pD8JCwlHlQOAlDne6zywAxuEDuYde2PmlTpXVUdUrLcUvzSt9A==
```
Another way is to verify the signature of the package (see resource below).

I decided to not spend more time on this as part of this PR. If there is an integrity issue with the downloaded gzipped package, it is impossible to unarchive it. We currently don't validate that the file has not been unintentionally modified.
We can leave with it for now IMHO. This PR already improves the previous situation.


### Resources

- https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity: provide details and how-to generate integrity string
- npm package signature
  - https://docs.npmjs.com/about-registry-signatures
  - https://docs.npmjs.com/verifying-the-pgp-signature-for-a-package-from-the-npm-public-registry
