### PR TITLE
feat: check integrity of all external JS loaded from CDN

### DIFF
--- a/demo/draw-path/index.html
+++ b/demo/draw-path/index.html
@@ -27,9 +27,7 @@ limitations under the License.
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
-            crossorigin="anonymous"></script>
-    <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo=" crossorigin="anonymous"></script>
     <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../static/js/use-case.js"></script>
     <script defer src="./js/paths.js"></script>

--- a/demo/monitoring-all-process-instances/index.html
+++ b/demo/monitoring-all-process-instances/index.html
@@ -25,9 +25,8 @@ limitations under the License.
     <script defer src="../../examples/static/js/link-to-sources.js"></script>
     <!-- load bpmn-visualization -->
     <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo="
-            crossorigin="anonymous"></script>
-    <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/values.js@2.0.0/dist/index.umd.js" integrity="sha256-lNJnNIdh5oXecah6rOix/TxyGcOYnfkybx4Qii2uxSo=" crossorigin="anonymous"></script>
+    <script defer src="https://variancecharts.com/cdn/variance-noncommercial-standalone-6d26aa2.min.js" charset="UTF-8" integrity="sha384-tWKnmvvtGH2MkH7CGAql3wuzSBBH6XF7vDfhqMd1uQ8Us1bcDbID5m915xGYODNA" crossorigin="anonymous"></script>
     <script defer src="../../examples/static/js/diagram/bpmn-diagrams.js"></script>
     <script defer src="../static/js/use-case.js"></script>
     <script defer src="js/execution-data/utils.js"></script>


### PR DESCRIPTION
This applies to the `variancecharts`.
Also stop loading it in the draw-path demo as it is not used there.

### Live environment of examples

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/feat/resource_integrity_external_lib/examples/index.html

### Resources

- https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity: provide details and how-to generate integrity string