### PR TITLE
chore: bump version of competitors in examples

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,6 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@13.0.4/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-ir1JRKKdwrP2SbqZzwTL1j8LF1NBwlEwm49sUEsYxTg=" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@14.0.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-Z4fbWZSuOVI43PUUUkPvaMTKlRl/OGFWAng1XPlBfDw=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>

--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,8 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script  defer src="https://cdn.jsdelivr.net/npm/bpmn-js@13.0.4/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-ir1JRKKdwrP2SbqZzwTL1j8LF1NBwlEwm49sUEsYxTg=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@13.0.4/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-ir1JRKKdwrP2SbqZzwTL1j8LF1NBwlEwm49sUEsYxTg=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@14.0.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-Z4fbWZSuOVI43PUUUkPvaMTKlRl/OGFWAng1XPlBfDw=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
   <script defer src="shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.28.0/dist/bpmn/index.js" integrity="sha256-axAhGJVTnpft43YZxo/HDX7yK8GH5fMQhCfkQLGXr9w=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.31.0/dist/bpmn/index.js" integrity="sha256-94rcvQYo9E72SxsezC6TG0UOah6+Ie4boLm+BqkCtEY=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.39.0/dist/bpmn-visualization.min.js" integrity="sha384-E2ofmlxS5nRTDew9wflMEYwva2yN5z16RmzyDVzNy2IyEYqqOlqOmrLXkNZpXSOQ" crossorigin="anonymous"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
- bpmn-js: 13.0.4 to 14.0.0
- kie-editors-standalone: 0.28.0 to 0.31.0

closes #539

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/9513bef/examples/index.html

<!--
https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/chore/bump_version_competitors/examples/index.html
-->
