### PR TITLE
chore: remove dependencies "overrides" in the parcel project

### DIFF
--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -15,10 +15,5 @@
     "@parcel/transformer-inline-string": "~2.9.3",
     "parcel": "~2.9.3",
     "typescript": "~4.5.5"
-  },
-  "overrides": {
-    "@parcel/optimizer-htmlnano": {
-      "htmlnano": "2.0.3"
-    }
   }
 }


### PR DESCRIPTION
This is not needed anymore because the transitive dependency that required it has been fixed.

closes #546