### PR TITLE
chore: update 3rd party libs used in examples

### DIFF
--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.html
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.html
@@ -44,9 +44,8 @@ limitations under the License.
             }
         </style>
         <!-- Popover and Tooltip support -->
-        <script defer src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha256-WgfGn5Bh6xLjmgMTWKT1Z/MKACrWGCY5rIT9G9ovbmU=" crossorigin="anonymous"></script>
-        <!-- Development version -->
-        <script defer src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.1/dist/tippy-bundle.umd.js" integrity="sha256-mII5pSbIKUGuLuv63S7irex7OpIvGzxRkcXP+jOAIu4=" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha256-whL0tQWoY1Ku1iskqPFvmZ+CHsvmRWx/PIoEvIeWh4I=" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.7/dist/tippy-bundle.umd.min.js" integrity="sha256-Pw/nDrJszyj2iHoZLinTjdfvfC8HmnMwStQt3HvtN94=" crossorigin="anonymous"></script>
 
         <script defer src="../../static/js/link-to-sources.js"></script>
         <!-- load bpmn-visualization -->

--- a/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
+++ b/examples/custom-behavior/select-elements-by-bpmn-kind/index.html
@@ -20,7 +20,7 @@ limitations under the License.
     <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
     <link rel="stylesheet" href="../../static/css/main.css" type="text/css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3.9.0/notyf.min.css" integrity="sha256-IwkvZNRC/3S26O1gWwjBINmrPZ4zYvPX4z/98OKWHkQ=" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3.10.0/notyf.min.css" integrity="sha256-IwkvZNRC/3S26O1gWwjBINmrPZ4zYvPX4z/98OKWHkQ=" crossorigin="anonymous">
     <style>
         #bpmn-container {
             left: 60px;
@@ -60,7 +60,7 @@ limitations under the License.
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_0.js"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_1_1.js"></script>
     <script defer src="../../static/js/diagram/bpmn-diagram-miwg-test-suite-c_2_0.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/notyf@3.9.0/notyf.min.js" integrity="sha256-94ygrajpwhaqxLOwPjuOZSUlCJ/KdtFefKg+Iu3WCAk=" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/notyf@3.10.0/notyf.min.js" integrity="sha256-UnlpkMLasaTx2ZqovxBXUcQ5jq3oKXaZZ1aWENNFETE=" crossorigin="anonymous"></script>
     <script defer src="index.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Updated resources
  - notyf from 3.9.0 to 3.10.0
  - popper.js from 2.9.2 to 2.11.8
  - tippy.js from 6.3.1 (development) to 6.3.7 (production minified)

closes #271

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/1d13196/examples/index.html
<!--
-->

```[tasklist]
### Tasks
- [x] bump notyf https://github.com/caroso1222/notyf/blob/master/CHANGELOG.md + get SRI in https://www.jsdelivr.com/package/npm/notyf
```
