### PR TITLE
chore(dev-deps): bump parcel from 2.9.3 to 2.10.0

### DIFF
--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,9 +11,9 @@
     "bpmn-visualization": "0.41.0"
   },
   "devDependencies": {
-    "@parcel/core": "~2.9.3",
-    "@parcel/transformer-inline-string": "~2.9.3",
-    "parcel": "~2.9.3",
+    "@parcel/core": "~2.10.0",
+    "@parcel/transformer-inline-string": "~2.10.0",
+    "parcel": "~2.10.0",
     "typescript": "~4.5.5"
   }
 }


### PR DESCRIPTION

### Notes

- I tested the dev server locally
- parcel changelog: https://github.com/parcel-bundler/parcel/releases/tag/v2.10.0