### PR TITLE
fix(BpmnSemantic): do not display properties with undefined values

### DIFF
--- a/examples/custom-behavior/javascript-tooltip-and-popover/index.js
+++ b/examples/custom-behavior/javascript-tooltip-and-popover/index.js
@@ -153,13 +153,14 @@ BPMN Info
 <hr>
 ${computeBpmnInfoForPopover(headerKeys, bpmnSemantic)}
 <br>
-${computeBpmnInfoForPopover(secondaryKeys, bpmnSemantic, true)}
+${computeBpmnInfoForPopover(secondaryKeys, bpmnSemantic, true, true)}
 </div>`;
 }
 
-function computeBpmnInfoForPopover(keys, bpmnSemantic, sort = false) {
+function computeBpmnInfoForPopover(keys, bpmnSemantic, sort = false, filterUndefinedValue = false) {
     return keys.map(key => getConvertedBpmnSemanticValue(key, bpmnSemantic))
       .sort((a, b) => sort ? a.key.localeCompare(b.key) : 0)
+      .filter(obj => filterUndefinedValue ? obj.value !== 'N/A' : true)
       .map(obj => `<b>${obj.key}</b>: ${obj.value}`)
       .join('<br>\n');
 }


### PR DESCRIPTION
Except for the "name" property (found in the header), only valued properties are displayed, so that only data of interest is shown.

closes #549

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/fix/549-hide_undefined_properties_of_BpmnSemantic/examples/custom-behavior/javascript-tooltip-and-popover/index.html
