### PR TITLE
chore(dev-deps): bump rollup dependencies

### DIFF
--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,16 +13,17 @@
     "bpmn-visualization": "0.42.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~25.0.5",
+    "@rollup/plugin-commonjs": "~25.0.7",
     "@rollup/plugin-node-resolve": "~15.2.3",
     "@rollup/plugin-terser": "~0.4.4",
-    "@rollup/plugin-typescript": "~11.1.5",
+    "@rollup/plugin-typescript": "~11.1.6",
+    "@types/node": "14.11.11",
     "rimraf": "~5.0.5",
-    "rollup": "~4.0.2",
+    "rollup": "~4.12.0",
     "rollup-plugin-copy": "~3.5.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",
-    "rollup-plugin-serve": "~2.0.2",
+    "rollup-plugin-serve": "~3.0.0",
     "rollup-plugin-string": "~3.0.0",
     "tslib": "~2.6.2",
     "typescript": "~4.5.5"


### PR DESCRIPTION
Also use a version of `@types/node` that is compatible with TypeScript 4.5.