### PR TITLE
refactor: use the new `getVersion` function

### DIFF
--- a/demo/static/js/use-case.js
+++ b/demo/static/js/use-case.js
@@ -37,7 +37,7 @@ class UseCase {
     _displayVersionInfoInFooter() {
         const footerElt = document.querySelector('footer');
         if (footerElt) {
-            const version = this._bpmnVisualization.getVersion();
+            const version = bpmnvisu.getVersion();
             footerElt.innerText = `bpmn-visualization@${version.lib}`;
         }
     }

--- a/projects/javascript-vanilla-with-webpack/src/index.js
+++ b/projects/javascript-vanilla-with-webpack/src/index.js
@@ -1,4 +1,4 @@
-import { BpmnVisualization, FitType } from 'bpmn-visualization';
+import { BpmnVisualization, FitType, getVersion } from 'bpmn-visualization';
 // this is simple example of the BPMN diagram, loaded as string. Load support provided by Webpack.
 // for other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './diagram.bpmn';
@@ -66,7 +66,7 @@ registry.addOverlays('Activity_083jf01',
 
 // display the bpmn-visualization version in the footer
 const footer = document.querySelector("footer");
-const version = bpmnVisualization.getVersion();
+const version = getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;
 const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
 footer.innerText = `${versionAsString} with ${dependenciesAsString}`;

--- a/projects/typescript-vanilla-with-parcel/src/index.ts
+++ b/projects/typescript-vanilla-with-parcel/src/index.ts
@@ -1,4 +1,4 @@
-import { mxgraph, BpmnVisualization, FitType } from "bpmn-visualization";
+import { mxgraph, BpmnVisualization, FitType, getVersion } from 'bpmn-visualization';
 // BPMN diagram content conveniently retrieved with parcel (as string)
 // for other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from "bundle-text:./diagram.bpmn";
@@ -12,7 +12,7 @@ const bpmnVisualization = new BpmnVisualization({
 
 // display the bpmn-visualization version in the footer
 const footer = document.querySelector("footer")!;
-const version = bpmnVisualization.getVersion();
+const version = getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;
 const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
 footer.innerText = `${versionAsString} with ${dependenciesAsString} | direct usage of mxGraph@${mxgraph.mxClient.VERSION}`;

--- a/projects/typescript-vanilla-with-rollup/src/index.ts
+++ b/projects/typescript-vanilla-with-rollup/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {BpmnVisualization} from "bpmn-visualization";
+import { BpmnVisualization, getVersion } from 'bpmn-visualization';
 // this is simple example of the BPMN diagram, loaded as string. Load support provided by rollup-plugin-string.
 // for other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from "./diagram.bpmn";
@@ -82,7 +82,7 @@ registry.addOverlays('Activity_083jf01',
 
 // display the bpmn-visualization version in the footer
 const footer = document.querySelector<HTMLElement>("footer")!;
-const version = bpmnVisualization.getVersion();
+const version = getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;
 const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
 footer.innerText = `${versionAsString} with ${dependenciesAsString}`;

--- a/projects/typescript-vanilla-with-vitejs/src/index.ts
+++ b/projects/typescript-vanilla-with-vitejs/src/index.ts
@@ -2,7 +2,7 @@ import './style.css';
 // this is simple example of the BPMN diagram, loaded as string. The '?.raw' extension support is provided by Vite.
 // for other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './diagram.bpmn?raw';
-import { BpmnVisualization, FitType, mxgraph } from 'bpmn-visualization';
+import { BpmnVisualization, FitType, getVersion, mxgraph } from 'bpmn-visualization';
 
 // instantiate BpmnVisualization, pass the container HTMLElement - present in index.html
 const bpmnVisualization = new BpmnVisualization({
@@ -68,7 +68,7 @@ registry.addOverlays('Activity_083jf01',
 
 // display the bpmn-visualization version in the footer
 const footer = document.querySelector<HTMLElement>('footer')!;
-const version = bpmnVisualization.getVersion();
+const version = getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;
 const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
 footer.innerText = `${versionAsString} with ${dependenciesAsString} | direct usage of mxGraph@${mxgraph.mxClient.VERSION}`;


### PR DESCRIPTION
`BpmnVisualization.getVersion` is now deprecated. Use the new function instead.

Closes #579

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/8a1520e8fa3f824ccbfcfb6efcffd85f436ac527/examples/index.html
