### PR TITLE
chore: bump version of competitors in examples

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@14.0.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-Z4fbWZSuOVI43PUUUkPvaMTKlRl/OGFWAng1XPlBfDw=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@17.9.2/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-vkmX0T5gLSRQYdah7xd/+RsT8Qc/gEywFz/miwbK5qw=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.43.0/dist/bpmn-visualization.min.js" integrity="sha384-RnOQRAIMMecdD2PwI4bFEpezqubX2zlLmWEOMftHXlyJ+XgfQDzBBmfr4PoYUFXI" crossorigin="anonymous"></script>
   <script defer src="shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -15,7 +15,7 @@ limitations under the License.
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>bpmn-visualization  - Comparison with kie-editors-standalone</title>
+  <title>bpmn-visualization - Comparison with kie-editors-standalone</title>
   <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
   <link rel="stylesheet" href="../../static/css/spectre.min.css" type="text/css">
   <link rel="stylesheet" href="../../static/css/icons.min.css" type="text/css">
@@ -57,7 +57,7 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.31.0/dist/bpmn/index.js" integrity="sha256-94rcvQYo9E72SxsezC6TG0UOah6+Ie4boLm+BqkCtEY=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.32.0/dist/bpmn/index.js" integrity="sha256-LRbqMHa0h8cMygLZ4/x4rKgP540ZJiGa6Bb8hh6woeM=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.43.0/dist/bpmn-visualization.min.js" integrity="sha384-RnOQRAIMMecdD2PwI4bFEpezqubX2zlLmWEOMftHXlyJ+XgfQDzBBmfr4PoYUFXI" crossorigin="anonymous"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
- bpmn-js: 14.0.0 to 17.9.2
- kie-editors-standalone: 0.31.0 to 0.32.0 (12.93 Mb uncompressed)

**Live environment of examples**

- home: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/ac98bcb/examples/index.html
- bpmn-js: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/ac98bcb/examples/misc/compare-with-bpmn-js/index.html
- kie: https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/ac98bcb/examples/misc/compare-with-kie-editors-standalone/index.html


### Screenshots

bpmn-js now supports rendering vertical pool.

Example with [miwg-test-suite A.4.1 diagram](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/cc75e467fd2b3009e67d4b24943591c66ce91a23/Reference/A.4.1.bpmn)


[14.0.0](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.43.0/examples/misc/compare-with-bpmn-js/index.html) | 17.9.2
---- | ----
![image](https://github.com/user-attachments/assets/39e9ce74-a4bd-450b-94ed-7b5b9b33985b) | ![image](https://github.com/user-attachments/assets/2514406a-5861-4e2a-b2d3-067dc8994e88)

