### PR TITLE
test(webpack): validate that bv-addons can be used without error

### DIFF
--- a/.github/workflows/check-projects.yml
+++ b/.github/workflows/check-projects.yml
@@ -46,15 +46,15 @@ jobs:
       matrix:
         project:
           - javascript-vanilla-with-webpack
-          - typescript-angular
-          - typescript-lit-element
-          - typescript-vanilla-with-parcel
-          - typescript-vanilla-with-rollup
-          - typescript-vanilla-with-rsbuild
-          - typescript-vanilla-with-vitejs
-          - typescript-vue
+#          - typescript-angular
+#          - typescript-lit-element
+#          - typescript-vanilla-with-parcel
+#          - typescript-vanilla-with-rollup
+#          - typescript-vanilla-with-rsbuild
+#          - typescript-vanilla-with-vitejs
+#          - typescript-vue
         bv-npm-package:
-          - development
+#          - development
           - release
     defaults:
       run:

--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -9,7 +9,7 @@
     "serve": "webpack serve"
   },
   "dependencies": {
-    "@process-analytics/bv-experimental-add-ons": "0.7.0",
+    "@process-analytics/bv-experimental-add-ons": "0.7.1",
     "bpmn-visualization": "0.44.0"
   },
   "devDependencies": {

--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -9,6 +9,7 @@
     "serve": "webpack serve"
   },
   "dependencies": {
+    "@process-analytics/bv-experimental-add-ons": "0.7.0",
     "bpmn-visualization": "0.44.0"
   },
   "devDependencies": {

--- a/projects/javascript-vanilla-with-webpack/src/index.js
+++ b/projects/javascript-vanilla-with-webpack/src/index.js
@@ -1,7 +1,11 @@
 import { BpmnVisualization, FitType, getVersion } from 'bpmn-visualization';
+import { ShapeUtil } from '@process-analytics/bv-experimental-add-ons';
 // this is simple example of the BPMN diagram, loaded as string. Load support provided by Webpack.
 // for other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './diagram.bpmn';
+
+// TMP to validate that the bv-addons dependency does not break the build
+console.info('bv-addons ShapeUtil', ShapeUtil.isBpmnArtifact('kind'))
 
 // instantiate the BpmnVisualization, pass the container HTMLElement - present in index.html
 const bpmnVisualization = new BpmnVisualization({ container: 'bpmn-container' });


### PR DESCRIPTION
Reproduce the problem that will be fixed by https://github.com/process-analytics/bv-experimental-add-ons/pull/301

### Notes

Current build error
```
WARNING in ./src/index.js 8:36-60
export 'ShapeUtil' (imported as 'ShapeUtil') was not found in '@process-analytics/bv-experimental-add-ons' (module has no exports)

ERROR in ./node_modules/@process-analytics/bv-experimental-add-ons/dist/index.js 16:0-32
Module not found: Error: Can't resolve './bpmn-elements' in '/development/process-analytics/repo/bpmn-visualization-examples/projects/javascript-vanilla-with-webpack/node_modules/@process-analytics/bv-experimental-add-ons/dist'
Did you mean 'bpmn-elements.js'?
BREAKING CHANGE: The request './bpmn-elements' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./src/index.js 2:0-71 8:36-60

ERROR in ./node_modules/@process-analytics/bv-experimental-add-ons/dist/index.js 17:0-24
Module not found: Error: Can't resolve './paths' in '/development/process-analytics/repo/bpmn-visualization-examples/projects/javascript-vanilla-with-webpack/node_modules/@process-analytics/bv-experimental-add-ons/dist'
Did you mean 'paths.js'?
BREAKING CHANGE: The request './paths' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./src/index.js 2:0-71 8:36-60

ERROR in ./node_modules/@process-analytics/bv-experimental-add-ons/dist/index.js 18:0-26
Module not found: Error: Can't resolve './plugins' in '/development/process-analytics/repo/bpmn-visualization-examples/projects/javascript-vanilla-with-webpack/node_modules/@process-analytics/bv-experimental-add-ons/dist'
Did you mean 'index.js'?
BREAKING CHANGE: The request './plugins' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./src/index.js 2:0-71 8:36-60

ERROR in ./node_modules/@process-analytics/bv-experimental-add-ons/dist/index.js 19:0-34
Module not found: Error: Can't resolve './plugins-support' in '/development/process-analytics/repo/bpmn-visualization-examples/projects/javascript-vanilla-with-webpack/node_modules/@process-analytics/bv-experimental-add-ons/dist'
Did you mean 'plugins-support.js'?
BREAKING CHANGE: The request './plugins-support' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./src/index.js 2:0-71 8:36-60

4 errors have detailed information that is not shown.
```