### PR TITLE
feat: add new miwg reference diagrams in the "load remote" example

### DIFF
--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
@@ -101,6 +101,7 @@ const miwgFileNames = [
   'B.1.0', 'B.2.0',
   'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
   'C.5.0', 'C.6.0', 'C.7.0', 'C.8.0', 'C.8.1',
+  'C.9.0', 'C.9.1', 'C.9.2'
   // extra file to get fetch error
   'do-not-exist',
   // extra file to get load error

--- a/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
+++ b/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.js
@@ -101,7 +101,7 @@ const miwgFileNames = [
   'B.1.0', 'B.2.0',
   'C.1.0', 'C.1.1', 'C.2.0', 'C.3.0', 'C.4.0',
   'C.5.0', 'C.6.0', 'C.7.0', 'C.8.0', 'C.8.1',
-  'C.9.0', 'C.9.1', 'C.9.2'
+  'C.9.0', 'C.9.1', 'C.9.2',
   // extra file to get fetch error
   'do-not-exist',
   // extra file to get load error


### PR DESCRIPTION
The files were recently added to the miwg-test-suite repository.

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/54ae2e23f6959d6e64f58f10bb4923707994d8e7/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html


<!--
https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/8f0b2c40283cc5f6f5af28d73016bf38939359c2/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/8f0b2c40283cc5f6f5af28d73016bf38939359c2/examples/index.html
-->

### Screnshots

C.9.0 | C.9.1 | C.9.2
---- | ---- | ----
![image](https://github.com/user-attachments/assets/1f2a0932-aba3-4f63-829d-d0e6eaca37ed) | ![image](https://github.com/user-attachments/assets/8a329091-675b-48e2-8b41-3e2631c11c47) | ![image](https://github.com/user-attachments/assets/7a307cd4-8bbb-4b99-887f-81124aace85b)
