### PR TITLE
chore(deps-dev): bump dependencies in projects

### DIFF
--- a/projects/javascript-vanilla-with-webpack/package.json
+++ b/projects/javascript-vanilla-with-webpack/package.json
@@ -12,9 +12,9 @@
     "bpmn-visualization": "0.46.0"
   },
   "devDependencies": {
-    "html-webpack-plugin": "~5.6.0",
-    "webpack": "~5.94.0",
-    "webpack-cli": "~5.1.4",
-    "webpack-dev-server": "~5.1.0"
+    "html-webpack-plugin": "~5.6.3",
+    "webpack": "~5.99.5",
+    "webpack-cli": "~6.0.1",
+    "webpack-dev-server": "~5.2.1"
   }
 }

--- a/projects/typescript-lit-element/package.json
+++ b/projects/typescript-lit-element/package.json
@@ -10,12 +10,12 @@
     "prepare": "patch-package"
   },
   "dependencies": {
-    "lit": "~2.7.5",
+    "lit": "~3.3.0",
     "bpmn-visualization": "0.46.0"
   },
   "devDependencies": {
     "patch-package": "~8.0.0",
-    "vite": "~5.4.7",
-    "typescript": "~4.1.6"
+    "vite": "~6.3.0",
+    "typescript": "~5.8.3"
   }
 }

--- a/projects/typescript-vanilla-with-parcel/package.json
+++ b/projects/typescript-vanilla-with-parcel/package.json
@@ -11,10 +11,10 @@
     "bpmn-visualization": "0.46.0"
   },
   "devDependencies": {
-    "@parcel/core": "~2.12.0",
-    "@parcel/transformer-inline-string": "~2.12.0",
+    "@parcel/core": "~2.14.4",
+    "@parcel/transformer-inline-string": "~2.14.4",
     "buffer": "^6.0.3",
-    "parcel": "~2.12.0",
+    "parcel": "~2.14.4",
     "typescript": "~4.5.5"
   },
   "alias": {

--- a/projects/typescript-vanilla-with-rollup/package.json
+++ b/projects/typescript-vanilla-with-rollup/package.json
@@ -13,13 +13,13 @@
     "bpmn-visualization": "0.46.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~28.0.0",
-    "@rollup/plugin-node-resolve": "~15.3.0",
+    "@rollup/plugin-commonjs": "~28.0.3",
+    "@rollup/plugin-node-resolve": "~16.0.1",
     "@rollup/plugin-terser": "~0.4.4",
-    "@rollup/plugin-typescript": "~12.1.0",
+    "@rollup/plugin-typescript": "~12.1.2",
     "@types/node": "14.11.11",
     "del-cli": "~5.1.0",
-    "rollup": "~4.24.0",
+    "rollup": "~4.40.0",
     "rollup-plugin-copy": "~3.5.0",
     "rollup-plugin-copy-watch": "~0.0.1",
     "rollup-plugin-livereload": "~2.0.5",

--- a/projects/typescript-vanilla-with-rsbuild/package.json
+++ b/projects/typescript-vanilla-with-rsbuild/package.json
@@ -11,7 +11,7 @@
     "bpmn-visualization": "0.46.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.0.5",
+    "@rsbuild/core": "1.3.7",
     "typescript": "~5.5.4"
   }
 }

--- a/projects/typescript-vanilla-with-vitejs/package.json
+++ b/projects/typescript-vanilla-with-vitejs/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "~4.5.5",
-    "vite": "~5.4.7"
+    "vite": "~6.3.0"
   }
 }

--- a/projects/typescript-vue/package.json
+++ b/projects/typescript-vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bpmn-visualization-ts-vue",
   "private": true,
+  "type": "module",
   "license": "Apache-2.0",
   "scripts": {
     "start": "vite",
@@ -11,12 +12,12 @@
     "@process-analytics/bpmn-visualization-addons": "0.8.0",
     "bpmn-visualization": "0.46.0",
     "spectre.css": "~0.5.9",
-    "vue": "~3.5.6"
+    "vue": "~3.5.13"
   },
   "devDependencies": {
-    "@babel/types": "~7.25.6",
-    "@vitejs/plugin-vue": "~5.1.4",
+    "@babel/types": "~7.27.0",
+    "@vitejs/plugin-vue": "~5.2.3",
     "typescript": "~5.2.2",
-    "vite": "~5.4.7"
+    "vite": "~6.3.0"
   }
 }


### PR DESCRIPTION
This includes:
- bump lit from 2.7.5 to 3.3.0
  @lit/reactive-element uses types introduced in TS 5.0. So bump typescript from 4.1.6 to 5.8.3.
- parcel from 2.12.0 to 2.14.4
- rollup from 4.24.0 to 4.40.0 (also bump plugins)
- rsbuild from 1.0.5 to 1.3.7
- vite from 5.4.7 to 6.3.0
- vue from 3.5.6 to 3.5.13 (and plugins)
  Switch to ESM to remove a vite warning
- webpack from 5.94.0 to 5.99.5

### Notes

Evolution of the bundle size, this is to measure the impact of the bump of fast-xml-parser in bpmn-visualization in https://github.com/process-analytics/bpmn-visualization-js/pull/3327#pullrequestreview-2773102076

example | 0.46.0 | dev [5aa8091](https://github.com/process-analytics/bpmn-visualization-js/tree/5aa8091daf0459afda7fd0bc13a42ab0b76291fc)
---- | ---- | ----
rollup | 992.6 kB | 993.4 kB
rsbuild | 959.8 kB | 953.7 kB
vite | 994.2 kB | 995.0 kB
webpack | 980.1 kB | 973.8 kB

