### PR TITLE
chore: bump version of competitors in examples

### DIFF
--- a/examples/misc/compare-with-bpmn-js/index.html
+++ b/examples/misc/compare-with-bpmn-js/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   </style>
   <script defer src="../../static/js/link-to-sources.js"></script>
   <!-- load bpmn-js viewer distro (with pan and zoom) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@17.9.2/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-vkmX0T5gLSRQYdah7xd/+RsT8Qc/gEywFz/miwbK5qw=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bpmn-js@18.5.0/dist/bpmn-navigated-viewer.production.min.js" integrity="sha256-nDLkOcUTZVEN4Qx/ioNMSH+yYgYk3NUbWMMW4AVaorc=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.46.0/dist/bpmn-visualization.min.js" integrity="sha384-+pA6hvphfoQkACQAPuFym7ssxg2C+Im5a3/t3t/yUWuIT/mP7c9tV8DMnrVKX/yd" crossorigin="anonymous"></script>
   <script defer src="shared.js"></script>

--- a/examples/misc/compare-with-kie-editors-standalone/index.html
+++ b/examples/misc/compare-with-kie-editors-standalone/index.html
@@ -57,7 +57,7 @@ limitations under the License.
   <script defer src="../../static/js/link-to-sources.js"></script>
   <script defer src="../../static/js/dom-helper.js"></script>
   <!-- load bpmn kie-editors-standalone -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@0.32.0/dist/bpmn/index.js" integrity="sha256-LRbqMHa0h8cMygLZ4/x4rKgP540ZJiGa6Bb8hh6woeM=" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@kie-tools/kie-editors-standalone@10.0.0/dist/bpmn/index.js" integrity="sha256-tJCefIWmL9iUGmiN5mNJm+RX3kyrzw4d5I9qMPPVDNI=" crossorigin="anonymous"></script>
   <!-- load bpmn-visualization -->
   <script defer src="https://cdn.jsdelivr.net/npm/bpmn-visualization@0.46.0/dist/bpmn-visualization.min.js" integrity="sha384-+pA6hvphfoQkACQAPuFym7ssxg2C+Im5a3/t3t/yUWuIT/mP7c9tV8DMnrVKX/yd" crossorigin="anonymous"></script>
   <script defer src="../compare-with-bpmn-js/shared.js"></script>


### PR DESCRIPTION
- bpmn-js: 17.9.2 to 18.5.0
- kie-editors-standalone: 0.32.0 to 10.0.0 (12.68 MB uncompressed)

**Live environment of examples**

https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/40ec6388/examples/index.html#miscellaneous


