### PR TITLE
chore(deps-dev): bump vue from 3.5.13 to 3.5.20

### DIFF
--- a/projects/typescript-vue/package.json
+++ b/projects/typescript-vue/package.json
@@ -12,12 +12,12 @@
     "@process-analytics/bpmn-visualization-addons": "0.8.0",
     "bpmn-visualization": "0.46.0",
     "spectre.css": "~0.5.9",
-    "vue": "~3.5.17"
+    "vue": "~3.5.20"
   },
   "devDependencies": {
     "@babel/types": "~7.27.0",
     "@vitejs/plugin-vue": "~5.2.4",
-    "typescript": "~5.2.2",
+    "typescript": "~5.4.5",
     "vite": "~6.3.0"
   }
 }

--- a/projects/typescript-vue/package.json
+++ b/projects/typescript-vue/package.json
@@ -12,11 +12,11 @@
     "@process-analytics/bpmn-visualization-addons": "0.8.0",
     "bpmn-visualization": "0.46.0",
     "spectre.css": "~0.5.9",
-    "vue": "~3.5.13"
+    "vue": "~3.5.17"
   },
   "devDependencies": {
     "@babel/types": "~7.27.0",
-    "@vitejs/plugin-vue": "~5.2.3",
+    "@vitejs/plugin-vue": "~5.2.4",
     "typescript": "~5.2.2",
     "vite": "~6.3.0"
   }


### PR DESCRIPTION
Also bump typescript from 5.2.2 to 5.4: the new vue version uses the `NoInfer` utility type introduced in TS 5.4.